### PR TITLE
Fix #5: FileChooserNative uses .show() instead of .present() in connection dialog

### DIFF
--- a/src/connection_dialog.py
+++ b/src/connection_dialog.py
@@ -166,7 +166,7 @@ class ConnectionDialog(Adw.Window):
             action=Gtk.FileChooserAction.OPEN,
         )
         dialog.connect('response', self._on_key_chosen)
-        dialog.show()
+        dialog.present()
 
     def _on_key_chosen(self, dialog, response):
         if response == Gtk.ResponseType.ACCEPT:


### PR DESCRIPTION
Closes #5

## Changes

Replace `dialog.show()` with `dialog.present()` on the `FileChooserNative` instance in `_on_browse_key`. `.show()` is GTK3 API; `.present()` is the correct GTK4 method.