### PR TITLE
Fix #6: non-atomic file writes in prefs.py and connections.py risk data corruption

### DIFF
--- a/src/connections.py
+++ b/src/connections.py
@@ -25,8 +25,10 @@ class ConnectionStore:
         return []
 
     def _save(self):
-        with open(CONNECTIONS_FILE, 'w') as f:
+        tmp = CONNECTIONS_FILE + '.tmp'
+        with open(tmp, 'w') as f:
             json.dump(self._connections, f, indent=2)
+        os.replace(tmp, CONNECTIONS_FILE)
 
     def list(self):
         return list(self._connections)

--- a/src/prefs.py
+++ b/src/prefs.py
@@ -21,5 +21,7 @@ def put(key, value):
     except (FileNotFoundError, json.JSONDecodeError):
         data = {}
     data[key] = value
-    with open(PREFS_FILE, 'w') as f:
+    tmp = PREFS_FILE + '.tmp'
+    with open(tmp, 'w') as f:
         json.dump(data, f, indent=2)
+    os.replace(tmp, PREFS_FILE)


### PR DESCRIPTION
Closes #6

## Changes

Both `prefs.py` and `connections.py` now write to a `.tmp` file first, then use `os.replace()` to atomically swap it into place. This ensures the target file is always either the old or new version — never a partial write that could corrupt saved preferences or connections.