### PR TITLE
Fix #21, #27, #32: Animated loading indicator and Enter key in database browser

### DIFF
--- a/src/db_browser.py
+++ b/src/db_browser.py
@@ -76,6 +76,9 @@ class DbBrowser(Gtk.Box):
         self.append(scroll)
 
     def clear(self):
+        self._load_gen += 1
+        self._loading_spinner.stop()
+        self._loading_bar.set_visible(False)
         self._store.clear()
 
     def load(self, conn):


### PR DESCRIPTION
## Summary

- **#21 / #27** `db_browser.py`: Replaced the static *"Connecting…"* tree row with an animated spinner bar at the top of the database browser panel. The bar is shown when `load()` is called and hidden once the schema populates or an error occurs — gives clear feedback during both initial SSH tunnel connections and connection switches
- **#32** `db_browser.py`: Added a `Gtk.EventControllerKey` to the tree view. Pressing Enter or Return on a selected table or view now emits `table-selected`, enabling full keyboard navigation of the database browser

## Test plan

- [ ] Click a connection — spinner bar appears at top of db browser while schema loads, then disappears
- [ ] Switch to a different connection — spinner reappears during reload
- [ ] Connect via SSH tunnel — spinner visible during tunnel + schema fetch
- [ ] Select a table in the db browser with keyboard, press Enter — table panel opens
- [ ] Press Enter on a schema/group row — nothing happens (not a table/view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)