### PR TITLE
Fix #47: Add search/filter to database browser

### DIFF
--- a/src/db_browser.py
+++ b/src/db_browser.py
@@ -117,8 +117,27 @@ class DbBrowser(Gtk.Box):
         return False
 
     def _on_search_changed(self, _entry):
-        self._filter.refilter()
-        self._tree.expand_all()
+        query = self._search_entry.get_text().strip()
+        if query:
+            if not self._saved_expansion:
+                self._saved_expansion = self._get_expanded_paths()
+            self._filter.refilter()
+            self._tree.expand_all()
+        else:
+            self._filter.refilter()
+            if self._saved_expansion is not None:
+                self._restore_expanded_paths(self._saved_expansion)
+                self._saved_expansion = None
+
+    def _get_expanded_paths(self):
+        expanded = []
+        self._tree.map_expanded_rows(lambda _tree, path: expanded.append(path.copy()))
+        return expanded
+
+    def _restore_expanded_paths(self, paths):
+        self._tree.collapse_all()
+        for path in paths:
+            self._tree.expand_row(path, False)
 
     def clear(self):
         self._load_gen += 1
@@ -131,6 +150,7 @@ class DbBrowser(Gtk.Box):
     def load(self, conn):
         self._load_gen += 1
         gen = self._load_gen
+        self._saved_expansion = None
         self._store.clear()
         self._search_entry.set_text('')
         self._loading_bar.set_visible(True)
@@ -215,6 +235,7 @@ class DbBrowser(Gtk.Box):
                     'dialog-information-symbolic', 'No views in this schema', 'info', conn, schema, ''
                 ])
 
+        self._saved_expansion = None
         self._search_entry.set_visible(True)
         self._tree.expand_all()
 


### PR DESCRIPTION
## Summary

- A search entry appears above the tree after a connection loads, cleared and hidden on disconnect
- Filters table and view names case-insensitively as you type; schema and group nodes are shown only when they have at least one matching descendant
- Matching rows are kept expanded automatically
- Placeholder text says "Filter…" to reflect that both tables and views are matched

## Test plan

- [ ] Connect to a database — confirm the search entry appears above the tree
- [ ] Type a partial table name — confirm only matching tables (and their parent schema/group) are shown
- [ ] Type a partial view name — confirm matching views are shown
- [ ] Clear the search — confirm full tree is restored
- [ ] Disconnect — confirm search entry is hidden and cleared
- [ ] Double-click a filtered result — confirm it opens the table inspector correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)