### PR TITLE
Fix #59: Show non-.sql files in file explorer as disabled

### DIFF
--- a/src/file_explorer.py
+++ b/src/file_explorer.py
@@ -177,6 +177,8 @@ class FileExplorer(Gtk.Box):
 
     def _on_row_activated(self, _tree, path, _col):
         it = self._store.get_iter(path)
+        if not self._store.get_value(it, COL_SENSITIVE):
+            return
         is_dir = self._store.get_value(it, COL_IS_DIR)
         fpath = self._store.get_value(it, COL_PATH)
         if is_dir:


### PR DESCRIPTION
## Summary

- Non-`.sql` files are now visible in the file explorer but fully disabled — greyed out icon and text, cannot be selected, double-click does nothing, no right-click context menu
- `.sql` files and directories behave exactly as before
- `_can_select()` simplified to use the new `COL_SENSITIVE` column

## Test plan

- [ ] Non-`.sql` files appear greyed out in the file explorer
- [ ] Double-clicking a non-`.sql` file does nothing
- [ ] Right-clicking a non-`.sql` file shows no context menu
- [ ] `.sql` files open normally on double-click
- [ ] Directories navigate normally on double-click

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)