### PR TITLE
Fix #63, #64: SQL autocomplete and query cancel button

### DIFF
--- a/src/sql_editor.py
+++ b/src/sql_editor.py
@@ -676,11 +676,13 @@ class SqlEditor(Gtk.Box):
                 connect_timeout=10,
             ) as db:
                 self._active_conn = db
+                cancelled = False
                 try:
                     with db.cursor() as cur:
                         for stmt in stmts:
                             if self._cancel_event.is_set():
                                 results.append({'stmt': stmt, 'kind': 'cancelled'})
+                                cancelled = True
                                 break
                             try:
                                 cur.execute(stmt)
@@ -695,6 +697,7 @@ class SqlEditor(Gtk.Box):
                                                     'count': count})
                             except psycopg.errors.QueryCanceled:
                                 results.append({'stmt': stmt, 'kind': 'cancelled'})
+                                cancelled = True
                                 break
                             except psycopg.Error as e:
                                 msg = e.diag.message_primary or str(e) if hasattr(e, 'diag') else str(e)
@@ -704,7 +707,10 @@ class SqlEditor(Gtk.Box):
                                     msg += f'\nHint: {e.diag.message_hint}'
                                 results.append({'stmt': stmt, 'kind': 'error', 'msg': msg})
                                 break  # transaction is aborted; stop here
-                    db.commit()
+                    if cancelled:
+                        db.rollback()
+                    else:
+                        db.commit()
                 finally:
                     self._active_conn = None
         except Exception as e:


### PR DESCRIPTION
## Summary
- **#63 SQL autocomplete**: Uses `GtkSource.CompletionWords` with a hidden buffer seeded with SQL keywords and schema objects fetched from `information_schema.columns`. Registers the buffer before calling `set_text` so the initial content fires the `changed` signal correctly.
- **#64 Cancel button**: Replaces `set_visible()` toggling on sibling buttons with a `Gtk.Stack` (named pages `run`/`cancel`) to avoid the `gtk_css_node_insert_after` CRITICAL. Uses `psycopg` `cancel_safe()` to interrupt running queries; catches `QueryCanceled` in both single- and multi-statement execution paths.

## Test plan
- [ ] Type `sel` in the SQL editor — autocomplete should suggest `select` and other keywords
- [ ] Connect to a DB, type a table/column name prefix — schema objects should appear in autocomplete
- [ ] Run a slow query, click Cancel — query should stop and show "Query cancelled"
- [ ] Run multiple statements and cancel mid-way — log should show cancelled entry with stop icon
- [ ] Verify no `gtk_css_node_insert_after` CRITICAL in console output

🤖 Generated with [Claude Code](https://claude.com/claude-code)