### PR TITLE
feat: Schema tab column management UI

### DIFF
--- a/src/column_dialogs.py
+++ b/src/column_dialogs.py
@@ -325,19 +325,22 @@ class SetDefaultDialog(Adw.Dialog):
 class ReorderColumnsDialog(Adw.Dialog):
     """Dialog for reordering table columns and generating a migration script.
 
-    schema       – schema name
-    table        – table name
-    columns      – list of column names in current order
-    on_execute(sql) – callback called when user confirms execution of migration
+    schema  – schema name
+    table   – table name
+    columns – list of column names in current order
+
+    The dialog only generates and copies the migration SQL; it does not execute
+    it directly.  The generated CREATE TABLE ... AS SELECT script does not
+    preserve constraints, indexes, triggers, or defaults, so it must be reviewed
+    and augmented before running.
     """
 
-    def __init__(self, schema, table, columns, on_execute):
+    def __init__(self, schema, table, columns, on_execute=None):
         super().__init__(title='Reorder Columns', content_width=500)
         self._schema = schema
         self._table = table
         self._original_order = list(columns)
         self._current_order = list(columns)
-        self._on_execute = on_execute
 
         header = Adw.HeaderBar()
         toolbar_view = Adw.ToolbarView()
@@ -414,12 +417,7 @@ class ReorderColumnsDialog(Adw.Dialog):
         copy_btn = Gtk.Button(label='Copy SQL')
         copy_btn.connect('clicked', self._copy_sql)
 
-        self._exec_btn = Gtk.Button(label='Execute Migration…')
-        self._exec_btn.add_css_class('destructive-action')
-        self._exec_btn.connect('clicked', self._confirm_execute)
-
         action_box.append(copy_btn)
-        action_box.append(self._exec_btn)
         outer.append(action_box)
 
         scroll = Gtk.ScrolledWindow()
@@ -487,6 +485,9 @@ class ReorderColumnsDialog(Adw.Dialog):
         tmp = f'{table}_reorder_tmp'
         col_list = ', '.join(qi(c) for c in cols)
         sql = (
+            f'-- WARNING: This script does NOT preserve constraints, indexes,\n'
+            f'-- triggers, defaults, sequences, or grants. Review and add them\n'
+            f'-- back manually before executing.\n\n'
             f'BEGIN;\n\n'
             f'-- Step 1: rename original table to a temp name\n'
             f'ALTER TABLE {qi(schema)}.{qi(table)} RENAME TO {qi(tmp)};\n\n'
@@ -512,29 +513,3 @@ class ReorderColumnsDialog(Adw.Dialog):
         )
         Gdk.Display.get_default().get_clipboard().set(text)
 
-    def _confirm_execute(self, _btn):
-        sql = self._sql_buf.get_text(
-            self._sql_buf.get_start_iter(),
-            self._sql_buf.get_end_iter(),
-            False,
-        )
-        dialog = Adw.AlertDialog(
-            heading=f'Execute migration on "{self._table}"?',
-            body='This will rename the original table, create a new one with the '
-                 'desired column order, then drop the original. '
-                 'The operation runs in a transaction and will be rolled back on failure. '
-                 'This cannot be undone if it succeeds.',
-        )
-        dialog.add_response('cancel', 'Cancel')
-        dialog.add_response('execute', 'Execute Migration')
-        dialog.set_response_appearance('execute', Adw.ResponseAppearance.DESTRUCTIVE)
-        dialog.set_default_response('cancel')
-        dialog.set_close_response('cancel')
-
-        def on_response(_d, response):
-            if response == 'execute':
-                self.close()
-                self._on_execute(sql)
-
-        dialog.connect('response', on_response)
-        dialog.present(self.get_root())

--- a/src/table_panel.py
+++ b/src/table_panel.py
@@ -172,6 +172,21 @@ _DDL_SQL = """
 """
 
 
+def _validate_sql_fragment(text):
+    """Reject SQL fragments that contain statement-terminating or comment characters.
+
+    Returns an error string if invalid, or None if the fragment is safe to embed.
+    User-supplied type names, default expressions, and USING clauses are passed
+    through pgsql.SQL() as literal SQL text, so we guard against multi-statement
+    injection at the application level.
+    """
+    forbidden = (';', '--', '/*', '*/', '\x00')
+    for token in forbidden:
+        if token in text:
+            return f'Invalid SQL fragment: "{token}" is not allowed in this field.'
+    return None
+
+
 class _SchemaRow(GObject.Object):
     """GObject wrapper for a schema column row, used in the schema ColumnView."""
     __gtype_name__ = 'TuskSchemaRow'
@@ -494,6 +509,7 @@ class TablePanel(Gtk.Box):
         col_view.set_hexpand(True)
 
         _right_clicked_row = [None]
+        _cell_hit = [False]
 
         for i, col_name in enumerate(_SCHEMA_COLS):
             factory = Gtk.SignalListItemFactory()
@@ -506,6 +522,7 @@ class TablePanel(Gtk.Box):
                 cell_gesture = Gtk.GestureClick(button=3)
                 def _on_cell_rclick(_g, _n, _x, _y, lbl=label):
                     _right_clicked_row[0] = getattr(lbl, '_item', None)
+                    _cell_hit[0] = True
                 cell_gesture.connect('pressed', _on_cell_rclick)
                 label.add_controller(cell_gesture)
                 list_item.set_child(label)
@@ -558,8 +575,9 @@ class TablePanel(Gtk.Box):
         popover.set_parent(col_view)
 
         def on_right_click(_gesture, _n, x, y):
-            if _right_clicked_row[0] is None:
+            if not _cell_hit[0]:
                 return
+            _cell_hit[0] = False
             rect = Gdk.Rectangle()
             rect.x, rect.y, rect.width, rect.height = int(x), int(y), 1, 1
             popover.set_pointing_to(rect)
@@ -581,6 +599,13 @@ class TablePanel(Gtk.Box):
         def on_save(name, pg_type, nullable, default, after_col):
             import psycopg
             from psycopg import sql as pgsql
+
+            for fragment, label in [(pg_type, 'Type'), (default, 'Default')]:
+                if fragment is not None:
+                    err = _validate_sql_fragment(fragment)
+                    if err:
+                        self._show_edit_error(f'{label}: {err}')
+                        return
 
             parts = [
                 pgsql.SQL('ALTER TABLE {}.{} ADD COLUMN {} {}').format(
@@ -628,29 +653,8 @@ class TablePanel(Gtk.Box):
     def _on_reorder_clicked(self, _btn):
         from column_dialogs import ReorderColumnsDialog
         col_names = [r[0] for r in getattr(self, '_schema_raw_rows', [])]
-        conn, schema, table = self._conn, self._current_schema, self._current_table
-
-        def on_execute(sql):
-            def run():
-                try:
-                    import psycopg
-                    from tunnel import open_tunnel
-                    with open_tunnel(conn) as (host, port), psycopg.connect(
-                        host=host, port=port,
-                        dbname=conn['database'], user=conn['username'],
-                        password=conn['password'], connect_timeout=10,
-                        autocommit=False,
-                    ) as db:
-                        with db.cursor() as cur:
-                            cur.execute(sql)
-                        db.commit()
-                    GLib.idle_add(self._reload_schema_tab)
-                except Exception as e:
-                    GLib.idle_add(self._show_edit_error, str(e))
-
-            threading.Thread(target=run, daemon=True).start()
-
-        ReorderColumnsDialog(schema, table, col_names, on_execute).present(self.get_root())
+        schema, table = self._current_schema, self._current_table
+        ReorderColumnsDialog(schema, table, col_names).present(self.get_root())
 
     # ── Per-column context menu actions ────────────────────────────────────
 
@@ -663,6 +667,13 @@ class TablePanel(Gtk.Box):
         def on_save(new_type, using_expr):
             import psycopg
             from psycopg import sql as pgsql
+
+            for fragment, label in [(new_type, 'Type'), (using_expr, 'USING expression')]:
+                if fragment is not None:
+                    err = _validate_sql_fragment(fragment)
+                    if err:
+                        self._show_edit_error(f'{label}: {err}')
+                        return
 
             if using_expr:
                 ddl = pgsql.SQL(
@@ -696,6 +707,10 @@ class TablePanel(Gtk.Box):
             from psycopg import sql as pgsql
 
             if expr:
+                err = _validate_sql_fragment(expr)
+                if err:
+                    self._show_edit_error(f'Default expression: {err}')
+                    return
                 ddl = pgsql.SQL(
                     'ALTER TABLE {}.{} ALTER COLUMN {} SET DEFAULT {}'
                 ).format(


### PR DESCRIPTION
## Summary
- Adds Add Column and Reorder Columns toolbar buttons to the Schema tab (tables only)
- Adds right-click context menu on schema rows: Change Type, Set Default, Toggle NOT NULL, Set as Primary Key, Drop Column
- New `column_dialogs.py` module with all column management dialogs and a reusable searchable PostgreSQL type picker

## Issues
Closes #83
Closes #84
Closes #106
Closes #107
Closes #108
Closes #109
Closes #110
Closes #111

## Test plan
- [ ] Schema toolbar is visible for tables, hidden for views
- [ ] Add Column dialog opens, type picker popover is searchable and fills entry on click
- [ ] Adding a column refreshes the Schema tab
- [ ] Position hint (After column) sets a `position:after:<col>` comment on the column
- [ ] Right-clicking a schema row shows context menu with all 5 actions
- [ ] Change Type pre-fills current type; USING expression field available; tab refreshes on success
- [ ] Set Default pre-fills current default; clearing drops the default
- [ ] Toggle NOT NULL pre-checks for existing NULLs and warns with count; tab refreshes
- [ ] Drop Column shows destructive confirmation; tab refreshes
- [ ] Set as Primary Key warns if PK already exists; Keys tab refreshes after
- [ ] Reorder Columns: Up/Down reorders list; Generate Migration SQL produces valid SQL; Copy works; Execute Migration shows confirmation and refreshes schema
- [ ] All error cases show an error dialog rather than crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)