### PR TITLE
feat: URI paste, connection string preview, copy as URI, pgpass import (#90–94)

### DIFF
--- a/src/connection_dialog.py
+++ b/src/connection_dialog.py
@@ -267,7 +267,14 @@ class ConnectionDialog(Adw.Window):
         two_col.append(left_col)
         two_col.append(right_col)
 
+        self._uri_error_label = Gtk.Label()
+        self._uri_error_label.add_css_class('error')
+        self._uri_error_label.set_xalign(0)
+        self._uri_error_label.set_wrap(True)
+        self._uri_error_label.set_visible(False)
+
         content.append(uri_group)
+        content.append(self._uri_error_label)
         content.append(two_col)
         content.append(self._keyring_warning)
 
@@ -332,14 +339,17 @@ class ConnectionDialog(Adw.Window):
                 raise ValueError('URI must start with postgresql:// or postgres://')
             host = parsed.hostname or 'localhost'
             port = parsed.port or 5432
-            database = parsed.path.lstrip('/') or 'postgres'
+            database = unquote(parsed.path.lstrip('/')) or 'postgres'
             username = unquote(parsed.username or '')
             password = unquote(parsed.password or '')
-        except Exception:
+        except Exception as e:
             self._uri_row.add_css_class('error')
+            self._uri_error_label.set_text(str(e))
+            self._uri_error_label.set_visible(True)
             return
 
         self._uri_row.remove_css_class('error')
+        self._uri_error_label.set_visible(False)
         self._host_row.set_text(host)
         self._port_row.set_text(str(port))
         self._database_row.set_text(database)
@@ -357,7 +367,7 @@ class ConnectionDialog(Adw.Window):
             port = int(self._port_row.get_text().strip())
         except ValueError:
             port = 5432
-        database = self._database_row.get_text().strip() or 'database'
+        database = quote(self._database_row.get_text().strip() or 'database', safe='')
         username = self._username_row.get_text().strip()
         if username:
             uri = f'postgresql://{quote(username, safe="")}@{host}:{port}/{database}'

--- a/src/meson.build
+++ b/src/meson.build
@@ -39,6 +39,7 @@ tusk_sources = [
   'sponsor_dialog.py',
   'row_edit_dialog.py',
   'tunnel.py',
+  'pgpass_dialog.py',
 ]
 
 install_data(tusk_sources, install_dir: pkgdatadir)

--- a/src/pgpass_dialog.py
+++ b/src/pgpass_dialog.py
@@ -42,41 +42,45 @@ def parse_pgpass(path):
     if not os.path.exists(path):
         return entries, warnings
 
-    # Warn if permissions are too open (psql refuses to use it if world-readable)
-    st = os.stat(path)
-    if st.st_mode & (stat.S_IRWXG | stat.S_IRWXO):
-        mode_str = oct(stat.S_IMODE(st.st_mode))
-        warnings.append(
-            f'.pgpass permissions are {mode_str} — they should be 0600. '
-            'Credentials may be exposed to other users on this system.'
-        )
+    try:
+        # Warn if permissions are too open (psql refuses to use it if world-readable)
+        st = os.stat(path)
+        if st.st_mode & (stat.S_IRWXG | stat.S_IRWXO):
+            mode_str = oct(stat.S_IMODE(st.st_mode))
+            warnings.append(
+                f'.pgpass permissions are {mode_str} — they should be 0600. '
+                'Credentials may be exposed to other users on this system.'
+            )
 
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith('#'):
-                continue
-            fields = _split_pgpass_line(line)
-            if len(fields) != 5:
-                continue
-            hostname, port_str, database, username, password = fields
+        with open(path, encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
+                fields = _split_pgpass_line(line)
+                if len(fields) != 5:
+                    continue
+                hostname, port_str, database, username, password = fields
 
-            # Skip wildcard hostnames — they can't map to a specific connection
-            if hostname == '*':
-                continue
+                # Skip entries with wildcards in any field — they can't map to a
+                # specific connection without manual completion
+                if '*' in (hostname, port_str, database, username, password):
+                    continue
 
-            try:
-                port = int(port_str) if port_str != '*' else 5432
-            except ValueError:
-                port = 5432
+                try:
+                    port = int(port_str)
+                except ValueError:
+                    port = 5432
 
-            entries.append({
-                'hostname': hostname,
-                'port': port,
-                'database': database if database != '*' else 'postgres',
-                'username': username,
-                'password': password,
-            })
+                entries.append({
+                    'hostname': hostname,
+                    'port': port,
+                    'database': database,
+                    'username': username,
+                    'password': password,
+                })
+    except (OSError, UnicodeDecodeError) as e:
+        warnings.append(f'Could not read ~/.pgpass: {e}')
 
     return entries, warnings
 

--- a/src/window.py
+++ b/src/window.py
@@ -434,7 +434,7 @@ class TuskWindow(Adw.ApplicationWindow):
         user = quote(conn['username'], safe='')
         host = conn['host']
         port = conn['port']
-        database = conn['database']
+        database = quote(conn['database'], safe='')
         uri = f'postgresql://{user}@{host}:{port}/{database}'
         Gdk.Display.get_default().get_clipboard().set(uri)
         toast = Adw.Toast(title='URI copied to clipboard')
@@ -456,14 +456,25 @@ class TuskWindow(Adw.ApplicationWindow):
             dialog.present()
             return
 
-        entries, warnings = parse_pgpass(pgpass_path)
+        try:
+            entries, warnings = parse_pgpass(pgpass_path)
+        except Exception as e:
+            dialog = Adw.MessageDialog(
+                transient_for=self,
+                heading='Could Not Read .pgpass',
+                body=str(e),
+            )
+            dialog.add_response('ok', 'OK')
+            dialog.present()
+            return
+
         if not entries:
             dialog = Adw.MessageDialog(
                 transient_for=self,
                 heading='No Importable Entries',
                 body=(
                     '~/.pgpass contains no importable entries. '
-                    'Entries with wildcard hostnames (*) are skipped.'
+                    'Entries with wildcards (*) in any field are skipped.'
                 ),
             )
             dialog.add_response('ok', 'OK')


### PR DESCRIPTION
## Summary
- Add a "Paste PostgreSQL URI" row at the top of the connection dialog — pressing Enter or the arrow button parses the URI and fills all form fields automatically (#90)
- Add a live "Connection String" preview expander in the dialog that updates as fields are edited, with a copy button (#94)
- Add "Copy as URI" to the connection row menu — copies postgresql://user@host:port/db to the clipboard and shows a toast (#91)
- Add "Import from .pgpass…" to the + split button — parses ~/.pgpass, shows a checklist dialog with permission warnings, and saves selected entries as connections (#93)
- Redesign the connection dialog as a 2-column layout (820px) to eliminate vertical scrolling

## Issues
Closes #90
Closes #91
Closes #93
Closes #94

## Test plan
- Paste `postgresql://alice:s3cr3t@db.example.com:5433/myapp` into the URI row → fields populate, name auto-fills, row clears
- Paste an invalid URI → row gets red error border, no fields change
- Open the "Connection String" expander → live URI updates as Host/Port/Database/Username change; copy button works
- Open a connection row menu → "Copy as URI" appears; clicking it copies the URI and shows a toast (no password included)
- Click the dropdown on + → "Import from .pgpass…" opens; entries are listed with checkboxes; deselecting skips an entry on import
- With ~/.pgpass at 0644 permissions → warning banner appears in the import dialog
- Without ~/.pgpass → "No .pgpass File" message shown