### PR TITLE
feat: harden destructive action dialogs

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -639,7 +639,7 @@ class TuskWindow(Adw.ApplicationWindow):
         entry = Gtk.Entry(placeholder_text=dbname, hexpand=True)
         entry_row = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
         entry_label = Gtk.Label(
-            label=f'Type <b>{dbname}</b> to confirm',
+            label=f'Type <b>{GLib.markup_escape_text(dbname)}</b> to confirm',
             use_markup=True,
             xalign=0,
         )


### PR DESCRIPTION
## Summary
- Drop database now requires typing the database name to confirm — button
  stays disabled until the exact name is entered (case-sensitive)
- CASCADE drop dialogs for tables and schemas now explicitly name what
  will be removed (views, constraints, tables) instead of vague "dependent objects"
- Truncate dialog body rewritten to clearly state permanence and scope

## Issues
Closes #140
Closes #141
Closes #142

## Test plan
- Right-click a database → Drop: confirm button is disabled; typing a
  wrong name keeps it disabled; typing the exact name enables it
- Right-click a table → Drop: verify CASCADE checkbox reads "also drops
  all dependent views and constraints"
- Right-click a schema → Drop: verify CASCADE checkbox reads "also drops
  all tables, views and other objects in this schema"
- Drop a table that has dependents (without CASCADE): verify the error
  dialog body mentions "views and constraints"
- Right-click a table → Truncate: verify body reads "Truncate empties
  the table but keeps its structure and indexes. This cannot be undone."