### PR TITLE
feat: connection dialog polish (#132, #144, #150)

### DIFF
--- a/src/connection_dialog.py
+++ b/src/connection_dialog.py
@@ -37,7 +37,7 @@ class ConnectionDialog(Adw.Window):
         self._build_ui()
         if duplicate:
             self.connect('map', lambda _: self._name_row.grab_focus())
-        self.connect('close-request', self._on_close_request)
+
 
     def _build_ui(self):
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -333,8 +333,6 @@ class ConnectionDialog(Adw.Window):
         btn.set_icon_name('object-select-symbolic')
         GLib.timeout_add(1500, lambda: btn.set_icon_name('edit-copy-symbolic') or False)
 
-    def _on_close_request(self, _):
-        return False
 
     def _current_params(self):
         try:


### PR DESCRIPTION
## Summary
- Removed the Browse databases button — `Gtk.Popover` inside a modal `Adw.Window` permanently grabs input on Wayland, freezing the app
- Read-only toggle subtitle now includes context: "Recommended for production databases"
- SSH tunnel expander now has a subtitle explaining when to use it
- Connection String URI preview is now always visible inline (was hidden behind an expander)

## Issues
Closes #132
Closes #144
Closes #150

## Test plan
- [ ] Open New Connection dialog — Connection String row visible immediately in the Database group, updates live as fields are filled
- [ ] Read-only toggle subtitle reads "Prevents accidental writes. Recommended for production databases."
- [ ] SSH Tunnel expander shows subtitle without expanding it
- [ ] No folder/browse icon on the Database field
- [ ] No app freeze when opening any connection dialog