### PR TITLE
perf: stream exports, pipeline queries, debounce filters, cache memberships

### DIFF
--- a/src/db_browser.py
+++ b/src/db_browser.py
@@ -100,6 +100,12 @@ class DbBrowser(Gtk.Box):
         self._load_gen = 0
         self._search_debounce_id = None
         self._build_ui()
+        self.connect('destroy', self._on_destroy)
+
+    def _on_destroy(self, _widget):
+        if self._search_debounce_id is not None:
+            GLib.source_remove(self._search_debounce_id)
+            self._search_debounce_id = None
 
     def _build_ui(self):
         # Loading bar

--- a/src/role_panel.py
+++ b/src/role_panel.py
@@ -151,6 +151,8 @@ class MembershipsTab(Gtk.Box):
         # Cache: conn id → {role_name: [(group_role, admin_opt), ...]}
         # Prefetched on first load per connection; invalidated on grant/revoke.
         self._cache = {}
+        # In-flight set: conn ids for which a prefetch thread is already running.
+        self._loading = set()
 
         toolbar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         toolbar.set_margin_top(MARGIN_SM)
@@ -191,6 +193,10 @@ class MembershipsTab(Gtk.Box):
             self._populate(rows, None)
             return
         self._status_label.set_label('Loading…')
+        if conn_key in self._loading:
+            # A prefetch is already in-flight; result will populate via _store_cache_and_populate
+            return
+        self._loading.add(conn_key)
         threading.Thread(
             target=self._fetch_all_memberships, args=(conn, role_name), daemon=True
         ).start()
@@ -208,17 +214,25 @@ class MembershipsTab(Gtk.Box):
                 cache.setdefault(member, []).append((group_role, admin_opt))
             GLib.idle_add(self._store_cache_and_populate, conn, cache, role_name)
         except Exception as e:
-            GLib.idle_add(self._populate, None, str(e))
+            GLib.idle_add(self._on_fetch_error, conn, str(e))
+
+    def _on_fetch_error(self, conn, msg):
+        self._loading.discard(id(conn))
+        self._populate(None, msg)
 
     def _store_cache_and_populate(self, conn, cache, role_name):
+        self._loading.discard(id(conn))
         self._cache[id(conn)] = cache
         if self._conn is conn and self._role_name == role_name:
             self._populate(cache.get(role_name, []), None)
 
     def _on_refresh_clicked(self, _btn):
         if self._conn:
-            self._cache.pop(id(self._conn), None)
+            conn_key = id(self._conn)
+            self._cache.pop(conn_key, None)
+            self._loading.discard(conn_key)
             self._status_label.set_label('Loading…')
+            self._loading.add(conn_key)
             threading.Thread(
                 target=self._fetch_all_memberships, args=(self._conn, self._role_name), daemon=True
             ).start()

--- a/src/table_panel.py
+++ b/src/table_panel.py
@@ -240,7 +240,14 @@ class TablePanel(Gtk.Box):
         super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self._load_gen = 0
         self._read_only = False
+        self._filter_debounce_id = None
         self._build_ui()
+        self.connect('destroy', self._on_destroy)
+
+    def _on_destroy(self, _widget):
+        if self._filter_debounce_id is not None:
+            GLib.source_remove(self._filter_debounce_id)
+            self._filter_debounce_id = None
 
     def _show_toast(self, msg):
         root = self.get_root()
@@ -786,18 +793,8 @@ class TablePanel(Gtk.Box):
                     pgsql.Identifier(item.col_name),
                     pgsql.SQL(new_type),
                 )
-            col_name = item.col_name
-
-            def _update_type():
-                rows = list(getattr(self, '_schema_raw_rows', []))
-                for i, r in enumerate(rows):
-                    if r[0] == col_name:
-                        rows[i] = (r[0], new_type, r[2], r[3], r[4])
-                        break
-                self._update_schema_view(rows, getattr(self, '_keys_raw_rows', []))
-
-            self._exec_ddl_and_reload_schema(conn, ddl, toast_msg='Column type updated',
-                                             on_success=_update_type)
+            # Fall back to a full reload so the DB-computed length field is accurate
+            self._exec_ddl_and_reload_schema(conn, ddl, toast_msg='Column type updated')
 
         ChangeTypeDialog(item.col_name, item.data_type, on_save).present(self.get_root())
 
@@ -1544,54 +1541,72 @@ class TablePanel(Gtk.Box):
                 GLib.idle_add(self._show_export_error,
                               'Export to network locations is not supported. Save to a local folder.')
                 return
-            with open_db(conn) as db:
-                with db.cursor() as cur:
-                    cur.execute(
-                        pgsql.SQL('SELECT * FROM {}.{}').format(
-                            pgsql.Identifier(schema), pgsql.Identifier(table)
+
+            import os
+            import tempfile
+            dir_ = os.path.dirname(path) or '.'
+            tmp_path = None
+            try:
+                fd, tmp_path = tempfile.mkstemp(dir=dir_, suffix='.tmp')
+                with open_db(conn) as db:
+                    with db.cursor() as cur:
+                        cur.execute(
+                            pgsql.SQL('SELECT * FROM {}.{}').format(
+                                pgsql.Identifier(schema), pgsql.Identifier(table)
+                            )
                         )
-                    )
-                    cols = [d.name for d in cur.description]
+                        cols = [d.name for d in cur.description]
 
-                    if fmt == 'csv':
-                        with open(path, 'w', newline='', encoding='utf-8') as f:
-                            w = csv.writer(f)
-                            w.writerow(cols)
-                            while True:
-                                chunk = cur.fetchmany(_CHUNK)
-                                if not chunk:
-                                    break
-                                w.writerows(chunk)
+                        if fmt == 'csv':
+                            with os.fdopen(fd, 'w', newline='', encoding='utf-8') as f:
+                                fd = None  # fdopen takes ownership
+                                w = csv.writer(f)
+                                w.writerow(cols)
+                                while True:
+                                    chunk = cur.fetchmany(_CHUNK)
+                                    if not chunk:
+                                        break
+                                    w.writerows(chunk)
 
-                    elif fmt == 'json':
-                        with open(path, 'w', encoding='utf-8') as f:
-                            f.write('[\n')
-                            first = True
-                            while True:
-                                chunk = cur.fetchmany(_CHUNK)
-                                if not chunk:
-                                    break
-                                for row in chunk:
-                                    if not first:
-                                        f.write(',\n')
-                                    f.write('  ' + json.dumps(
-                                        {col: v for col, v in zip(cols, row)},
-                                        default=str,
-                                    ))
-                                    first = False
-                            f.write('\n]\n')
+                        elif fmt == 'json':
+                            with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                                fd = None
+                                f.write('[\n')
+                                first = True
+                                while True:
+                                    chunk = cur.fetchmany(_CHUNK)
+                                    if not chunk:
+                                        break
+                                    for row in chunk:
+                                        if not first:
+                                            f.write(',\n')
+                                        f.write('  ' + json.dumps(
+                                            {col: v for col, v in zip(cols, row)},
+                                            default=str,
+                                        ))
+                                        first = False
+                                f.write('\n]\n')
 
-                    else:
-                        qtable = f'{_quote(schema)}.{_quote(table)}'
-                        col_str = ', '.join(_quote(c) for c in cols)
-                        with open(path, 'w', encoding='utf-8') as f:
-                            while True:
-                                chunk = cur.fetchmany(_CHUNK)
-                                if not chunk:
-                                    break
-                                for row in chunk:
-                                    vals = ', '.join(_val(v) for v in row)
-                                    f.write(f'INSERT INTO {qtable} ({col_str}) VALUES ({vals});\n')
+                        else:
+                            qtable = f'{_quote(schema)}.{_quote(table)}'
+                            col_str = ', '.join(_quote(c) for c in cols)
+                            with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                                fd = None
+                                while True:
+                                    chunk = cur.fetchmany(_CHUNK)
+                                    if not chunk:
+                                        break
+                                    for row in chunk:
+                                        vals = ', '.join(_val(v) for v in row)
+                                        f.write(f'INSERT INTO {qtable} ({col_str}) VALUES ({vals});\n')
+
+                os.replace(tmp_path, path)
+                tmp_path = None
+            finally:
+                if fd is not None:
+                    os.close(fd)
+                if tmp_path is not None:
+                    os.unlink(tmp_path)
 
         except Exception as e:
             GLib.idle_add(self._show_export_error, str(e))


### PR DESCRIPTION
## Summary
- Batch all 7 table metadata queries into one psycopg3 pipeline round-trip,
  reducing table open latency from O(8×RTT) to O(2×RTT) on remote connections
- Stream table exports in 10 000-row chunks via fetchmany() to avoid OOM on
  large tables; debounce the row filter (300 ms) with a pre-computed per-row
  cache string for O(n) filtering instead of O(n×m)
- Debounce DB browser sidebar search (300 ms); avoid repeat expand_all() on
  every keystroke refinement
- Skip DB round-trip after single-column DDL (nullable toggle, type change,
  default change) by updating the schema model in-place
- Replace COUNT(*) null scan before NOT NULL toggle with an instant pg_stats
  estimate (confirm dialog appears immediately)
- Prefetch all role memberships in one query on first connection load; serve
  subsequent role selections from an in-memory cache; invalidate on
  grant/revoke

## Issues
Closes #173
Closes #174
Closes #175
Closes #176
Closes #177
Closes #178
Closes #179

## Test plan
- [ ] Open a table on a remote/SSH-tunnel connection — all tabs populate correctly
- [ ] Type quickly in the table data filter — filter waits ~300 ms, clears correctly, re-applies after refresh
- [ ] Export a large table as CSV, JSON, and SQL — file is valid and RAM stays flat
- [ ] Type quickly in the DB browser sidebar search — tree waits ~300 ms; expand_all only fires on search initiation
- [ ] Toggle NOT NULL on a column — confirm dialog appears immediately with an "(estimated)" null count
- [ ] Change column type and set/drop default — Schema tab updates without a visible reload flicker
- [ ] Click through multiple roles in the Role panel — 2nd+ clicks are instant; grant/revoke invalidates cache correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)