### PR TITLE
feat: inline cell editing in the data browser

### DIFF
--- a/src/data_grid.py
+++ b/src/data_grid.py
@@ -319,7 +319,8 @@ class PinColumnView(Gtk.Box):
         self._table_name = table_name
         self._pinned = []   # ordered list of original column indices that are pinned
         self._inline_edit = False
-        self._boolean_cols = set()  # col names with data_type == 'boolean'
+        self._boolean_cols = set()   # col names with data_type == 'boolean'
+        self._pk_col_names = set()   # col names that are not inline-editable
 
         # Underlying store shared by both views
         self._store = Gio.ListStore(item_type=_Row)
@@ -397,17 +398,32 @@ class PinColumnView(Gtk.Box):
         for row in rows:
             self._store.append(_Row(list(row)))
 
-    def enable_inline_edit(self, schema_info):
+    def replace_row(self, row_item, col_idx, new_value):
+        """Update a single cell in the store without a full reload.
+
+        Splices in a new _Row so GTK rebinds the affected cells (same GObject
+        pointer is a no-op for on_bind; a new instance guarantees a rebind).
+        Returns True if the row was found and replaced, False if not in store.
+        """
+        for i in range(self._store.get_n_items()):
+            if self._store.get_item(i) is row_item:
+                updated = list(row_item._raw)
+                updated[col_idx] = new_value
+                self._store.splice(i, 1, [_Row(updated)])
+                return True
+        return False
+
+    def enable_inline_edit(self, schema_info, pk_cols=()):
         """Enable double-click inline editing.
 
         schema_info is [(col_name, data_type, is_nullable, default_val)].
-        Call immediately after construction; rebuilds columns so cells pick up
-        the double-click gesture.
+        pk_cols is a collection of column names that should not be editable.
+        Call immediately after construction; factories read _inline_edit lazily
+        when cells are first created, which hasn't happened yet at this call site.
         """
         self._inline_edit = True
         self._boolean_cols = {r[0] for r in schema_info if r[1] == 'boolean'}
-        # No rebuild needed — factories read _inline_edit lazily when cells
-        # are first created, which hasn't happened yet at this call site.
+        self._pk_col_names = set(pk_cols)
 
     # ── Inline edit ───────────────────────────────────────────────────────────
 
@@ -418,6 +434,9 @@ class PinColumnView(Gtk.Box):
             return
         raw = getattr(label, '_raw_value', None)
         col_name = self._columns[col_idx]
+
+        if col_name in self._pk_col_names:
+            return  # PK columns are not editable inline
 
         if col_name in self._boolean_cols:
             # Toggle boolean immediately — no popover needed
@@ -451,7 +470,7 @@ class PinColumnView(Gtk.Box):
             if committed[0]:
                 return
             committed[0] = True
-            text = entry.get_text()
+            text = entry.get_text().strip()
             new_value = None if text == '' else text
             popover.popdown()
             self.emit('cell-edited', row_item, col_idx, new_value)

--- a/src/table_panel.py
+++ b/src/table_panel.py
@@ -11,7 +11,7 @@ gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, GLib, Gio, GObject, Pango, Gdk
 
 import prefs
-from data_grid import make_column_view, update_column_view, make_pinnable_column_view, PinColumnView, _Row
+from data_grid import make_column_view, update_column_view, make_pinnable_column_view, PinColumnView
 from pg_errors import friendly_pg_error as _friendly_pg_error
 from style import MARGIN_XS, MARGIN_SM, MARGIN_MD
 
@@ -1667,7 +1667,7 @@ class TablePanel(Gtk.Box):
                     and self._schema_info
                 )
                 if inline_edit:
-                    col_view.enable_inline_edit(self._schema_info)
+                    col_view.enable_inline_edit(self._schema_info, pk_cols=self._pk_cols)
                     col_view.connect('cell-edited', self._on_cell_edited)
                 self._data_scroll.set_child(col_view)
                 self._column_view = col_view
@@ -1947,6 +1947,8 @@ class TablePanel(Gtk.Box):
     def _on_cell_edited(self, _col_view, row_item, col_idx, new_value):
         if not self._pk_cols or col_idx >= len(self._all_data_cols):
             return
+        if self._all_data_cols[col_idx] in self._pk_cols:
+            return  # PK columns are not editable (belt-and-suspenders; gesture is also blocked)
         conn = self._conn
         schema, table = self._current_schema, self._current_table
         pk_cols, page = list(self._pk_cols), self._data_page
@@ -1961,21 +1963,13 @@ class TablePanel(Gtk.Box):
             daemon=True,
         ).start()
 
-    def _update_cell_in_place(self, row_item, col_idx, new_value):
-        """Update a single cell in the local store without reloading the page."""
+    def _apply_cell_update(self, conn, schema, table, page, row_item, col_idx, new_value):
+        """Update the cell in the store, falling back to a full reload if not found."""
         col_view = self._column_view
-        if not isinstance(col_view, PinColumnView):
+        if isinstance(col_view, PinColumnView) and col_view.replace_row(row_item, col_idx, new_value):
             return
-        store = col_view._store
-        for i in range(store.get_n_items()):
-            if store.get_item(i) is row_item:
-                # Build updated raw values and splice in a new _Row object.
-                # Splicing the same GObject instance back in is a no-op for GTK
-                # (same pointer → no rebind); a new instance guarantees on_bind fires.
-                updated = list(row_item._raw)
-                updated[col_idx] = new_value
-                store.splice(i, 1, [_Row(updated)])
-                break
+        # Row not in store (page changed, sort rebuilt, etc.) — reload to stay consistent.
+        self._reload_data_page(conn, schema, table, page)
 
     def _show_edit_dialog(self, initial_values):
         from row_edit_dialog import RowEditDialog
@@ -2138,10 +2132,16 @@ class TablePanel(Gtk.Box):
                         ),
                     )
                     cur.execute(query, set_vals + where_vals)
+                    rowcount = cur.rowcount
                 db.commit()
+            if rowcount == 0:
+                GLib.idle_add(self._show_toast, 'Row not found — may have been deleted')
+                GLib.idle_add(self._reload_data_page, conn, schema, table, page)
+                return
             GLib.idle_add(self._show_toast, 'Row updated')
             if row_item is not None and col_idx is not None:
-                GLib.idle_add(self._update_cell_in_place, row_item, col_idx, new_value_raw)
+                GLib.idle_add(self._apply_cell_update, conn, schema, table, page,
+                              row_item, col_idx, new_value_raw)
             else:
                 GLib.idle_add(self._reload_data_page, conn, schema, table, page)
         except Exception as e:


### PR DESCRIPTION
## Summary
- Adds double-click-to-edit for cells in the data browser table view (#219)
- Boolean columns toggle immediately on double-click; other columns show an inline popover with an Entry widget
- Commits the edit on Enter or focus-out, cancels on Escape; UPDATE is executed via a background thread using the table's primary key

## Issues
Closes #219

## Test plan
- Open a table with a primary key; double-click a text/numeric cell → popover appears with current value pre-filled
- Edit the value and press Enter → cell updates, row reflects new value after refresh
- Edit the value and click away (focus-out) → same commit behaviour
- Press Escape → popover closes, no update is sent
- Double-click a boolean column cell → value toggles immediately (no popover)
- Double-click a cell in a view or a table without a PK → no popover appears (read-only path)
- Verify no GTK CSS assertion errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)