### PR TITLE
fix: add python3-keyring to RPM spec Requires

### DIFF
--- a/packaging/rpm/tusk-gnome.spec.in
+++ b/packaging/rpm/tusk-gnome.spec.in
@@ -7,6 +7,7 @@ URL:            https://github.com/Shape-Machine/tusk-gnome
 
 Requires:       python3
 Requires:       python3-gobject
+Requires:       python3-keyring
 Requires:       gtk4
 Requires:       libadwaita
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -223,6 +223,7 @@ if [[ $DO_RPM == 1 ]]; then
         --maintainer "Shape Machine <tusk.gnome@shapemachine.xyz>" \
         --depends "python3" \
         --depends "python3-gobject" \
+        --depends "python3-keyring" \
         --depends "gtk4" \
         --depends "libadwaita" \
         --package "$DIST/tusk-gnome-$VERSION.rpm" \


### PR DESCRIPTION
## Summary
- `python3-keyring` was missing from the RPM spec's `Requires` list, causing Fedora users to hit a silent failure on launch unless they manually installed it
- Flatpak and AUR already declare this dependency correctly; this brings the RPM spec in line with both

## Issues
Closes #253

## Test plan
- [ ] Build the RPM and verify `python3-keyring` appears in `rpm -qR tusk-gnome`
- [ ] Install on a clean Fedora system without pre-installing python3-keyring — confirm it is pulled in automatically as a dep

🤖 Generated with [Claude Code](https://claude.com/claude-code)