### PR TITLE
feat: graphical EXPLAIN plan visualiser with ViewSwitcher and Copy menu

### DIFF
--- a/src/explain_graph.py
+++ b/src/explain_graph.py
@@ -179,3 +179,33 @@ class ExplainGraph(Gtk.DrawingArea):
         cr.set_source_rgba(1, 1, 1, 0.85)
         cr.move_to(x + 8, y + NODE_H - 22)
         PangoCairo.show_layout(cr, lo2)
+
+    # ── Export ────────────────────────────────────────────────────────────────
+
+    def render_to_png_bytes(self):
+        import io
+        import cairo
+        w = self.get_content_width()
+        h = self.get_content_height()
+        if not w or not h:
+            return None
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, w, h)
+        cr = cairo.Context(surface)
+        self._on_draw(self, cr, w, h)
+        buf = io.BytesIO()
+        surface.write_to_png(buf)
+        return buf.getvalue()
+
+    def render_to_svg_bytes(self):
+        import io
+        import cairo
+        w = self.get_content_width()
+        h = self.get_content_height()
+        if not w or not h:
+            return None
+        buf = io.BytesIO()
+        surface = cairo.SVGSurface(buf, w, h)
+        cr = cairo.Context(surface)
+        self._on_draw(self, cr, w, h)
+        surface.finish()
+        return buf.getvalue()

--- a/src/explain_graph.py
+++ b/src/explain_graph.py
@@ -28,7 +28,10 @@ class ExplainGraph(Gtk.DrawingArea):
     # ── Public API ────────────────────────────────────────────────────────────
 
     def set_plan(self, plan_json):
+        self._nodes = []
+        self._edges = []
         if not plan_json or not isinstance(plan_json, list):
+            self.queue_draw()
             return
         top = plan_json[0].get('Plan', {})
         self._build_layout(top)

--- a/src/explain_graph.py
+++ b/src/explain_graph.py
@@ -1,0 +1,181 @@
+import math
+
+import gi
+
+gi.require_version('Gtk', '4.0')
+gi.require_version('Pango', '1.0')
+gi.require_version('PangoCairo', '1.0')
+
+from gi.repository import Gtk, Pango, PangoCairo  # noqa: E402
+
+NODE_W   = 192
+NODE_H   = 78
+H_GAP    = 20   # horizontal gap between sibling subtrees
+V_GAP    = 52   # vertical gap between levels
+MARGIN   = 28
+CORNER_R = 9
+
+
+class ExplainGraph(Gtk.DrawingArea):
+    """Cairo-rendered top-down EXPLAIN plan node graph."""
+
+    def __init__(self):
+        super().__init__()
+        self._nodes = []   # (cx, cy, node_dict, cost_ratio)
+        self._edges = []   # (x1, y1, x2, y2)
+        self.set_draw_func(self._on_draw)
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def set_plan(self, plan_json):
+        if not plan_json or not isinstance(plan_json, list):
+            return
+        top = plan_json[0].get('Plan', {})
+        self._build_layout(top)
+        self.queue_draw()
+
+    # ── Layout ────────────────────────────────────────────────────────────────
+
+    def _subtree_width(self, node):
+        kids = node.get('Plans', [])
+        if not kids:
+            return NODE_W
+        kids_w = sum(self._subtree_width(k) for k in kids) + H_GAP * (len(kids) - 1)
+        return max(NODE_W, kids_w)
+
+    def _tree_depth(self, node):
+        kids = node.get('Plans', [])
+        return 1 + (max(self._tree_depth(k) for k in kids) if kids else 0)
+
+    def _build_layout(self, root):
+        max_cost = [1e-9]
+
+        def _scan(n):
+            max_cost[0] = max(max_cost[0], n.get('Total Cost', 0.0))
+            for c in n.get('Plans', []):
+                _scan(c)
+        _scan(root)
+
+        self._nodes = []
+        self._edges = []
+
+        def _place(node, left, level, parent_cx=None, parent_bottom=None):
+            sw = self._subtree_width(node)
+            cx = left + sw / 2
+            cy = MARGIN + level * (NODE_H + V_GAP)
+            ratio = node.get('Total Cost', 0.0) / max_cost[0]
+            self._nodes.append((cx, cy, node, ratio))
+            if parent_cx is not None:
+                self._edges.append((
+                    parent_cx, parent_bottom,
+                    cx,        cy,
+                ))
+            kids = node.get('Plans', [])
+            kx = left
+            for k in kids:
+                _place(k, kx, level + 1, cx, cy + NODE_H)
+                kx += self._subtree_width(k) + H_GAP
+
+        _place(root, MARGIN, 0)
+
+        depth     = self._tree_depth(root)
+        canvas_w  = self._subtree_width(root) + MARGIN * 2
+        canvas_h  = MARGIN + depth * (NODE_H + V_GAP) + MARGIN
+        self.set_content_width(int(canvas_w))
+        self.set_content_height(int(canvas_h))
+
+    # ── Drawing ───────────────────────────────────────────────────────────────
+
+    def _cost_color(self, ratio):
+        """Map 0→1 cost ratio to an RGB colour: blue → teal → yellow → red."""
+        if ratio < 0.33:
+            t = ratio / 0.33
+            return (0.11 + t * 0.10, 0.44 + t * 0.22, 0.85 - t * 0.35)
+        if ratio < 0.66:
+            t = (ratio - 0.33) / 0.33
+            return (0.21 + t * 0.68, 0.66 - t * 0.25, 0.50 - t * 0.46)
+        t = (ratio - 0.66) / 0.34
+        return (0.89 + t * (0.75 - 0.89), 0.41 - t * 0.30, 0.04)
+
+    def _rounded_rect(self, cr, x, y, w, h, r):
+        cr.new_sub_path()
+        cr.arc(x + w - r, y + r,     r,  -math.pi / 2, 0)
+        cr.arc(x + w - r, y + h - r, r,   0,            math.pi / 2)
+        cr.arc(x + r,     y + h - r, r,   math.pi / 2,  math.pi)
+        cr.arc(x + r,     y + r,     r,   math.pi,      3 * math.pi / 2)
+        cr.close_path()
+
+    def _on_draw(self, _area, cr, _width, _height):
+        # Background — honour light/dark theme
+        fg = self.get_style_context().get_color()
+        dark = (fg.red + fg.green + fg.blue) / 3 > 0.5
+        if dark:
+            cr.set_source_rgb(0.13, 0.13, 0.13)
+        else:
+            cr.set_source_rgb(0.94, 0.94, 0.96)
+        cr.paint()
+
+        # Edges (bezier curves)
+        cr.set_line_width(2)
+        cr.set_source_rgba(0.55, 0.55, 0.55, 0.75)
+        for x1, y1, x2, y2 in self._edges:
+            mid_y = (y1 + y2) / 2
+            cr.move_to(x1, y1)
+            cr.curve_to(x1, mid_y, x2, mid_y, x2, y2)
+            cr.stroke()
+
+        # Nodes
+        for cx, cy, node, ratio in self._nodes:
+            self._draw_node(cr, cx, cy, node, ratio)
+
+    def _draw_node(self, cr, cx, cy, node, ratio):
+        x = cx - NODE_W / 2
+        y = cy
+        r, g, b = self._cost_color(ratio)
+
+        # Filled rounded rectangle
+        self._rounded_rect(cr, x, y, NODE_W, NODE_H, CORNER_R)
+        cr.set_source_rgb(r, g, b)
+        cr.fill_preserve()
+        cr.set_source_rgba(0, 0, 0, 0.18)
+        cr.set_line_width(1)
+        cr.stroke()
+
+        # Node-type label (bold)
+        node_type = node.get('Node Type', '?')
+        relation  = node.get('Relation Name', '')
+        title     = f'{node_type}\n{relation}' if relation else node_type
+
+        lo = PangoCairo.create_layout(cr)
+        lo.set_font_description(Pango.FontDescription.from_string('Sans Bold 9'))
+        lo.set_width(int((NODE_W - 16) * Pango.SCALE))
+        lo.set_ellipsize(Pango.EllipsizeMode.END)
+        lo.set_alignment(Pango.Alignment.CENTER)
+        lo.set_text(title, -1)
+
+        cr.set_source_rgb(1, 1, 1)
+        cr.move_to(x + 8, y + 7)
+        PangoCairo.show_layout(cr, lo)
+
+        # Stats line (small)
+        cost        = node.get('Total Cost', 0.0)
+        plan_rows   = node.get('Plan Rows', '?')
+        actual_rows = node.get('Actual Rows')
+        actual_time = node.get('Actual Total Time')
+
+        parts = [f'cost {cost:.1f}', f'~{plan_rows}r']
+        if actual_rows is not None:
+            parts.append(f'actual {actual_rows}r')
+        if actual_time is not None:
+            parts.append(f'{actual_time:.1f}ms')
+
+        lo2 = PangoCairo.create_layout(cr)
+        lo2.set_font_description(Pango.FontDescription.from_string('Sans 7'))
+        lo2.set_width(int((NODE_W - 16) * Pango.SCALE))
+        lo2.set_ellipsize(Pango.EllipsizeMode.END)
+        lo2.set_alignment(Pango.Alignment.CENTER)
+        lo2.set_text(' · '.join(parts), -1)
+
+        cr.set_source_rgba(1, 1, 1, 0.85)
+        cr.move_to(x + 8, y + NODE_H - 22)
+        PangoCairo.show_layout(cr, lo2)

--- a/src/explain_graph.py
+++ b/src/explain_graph.py
@@ -194,7 +194,7 @@ class ExplainGraph(Gtk.DrawingArea):
             return None
         surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, w, h)
         cr = cairo.Context(surface)
-        self._on_draw(self, cr, w, h)
+        self._on_draw(None, cr, w, h)
         buf = io.BytesIO()
         surface.write_to_png(buf)
         return buf.getvalue()
@@ -209,6 +209,6 @@ class ExplainGraph(Gtk.DrawingArea):
         buf = io.BytesIO()
         surface = cairo.SVGSurface(buf, w, h)
         cr = cairo.Context(surface)
-        self._on_draw(self, cr, w, h)
+        self._on_draw(None, cr, w, h)
         surface.finish()
         return buf.getvalue()

--- a/src/sql_editor.py
+++ b/src/sql_editor.py
@@ -562,10 +562,13 @@ class SqlEditor(Gtk.Box):
         _s3.append('Copy SVG', 'explain-copy.copy-svg')
         _copy_menu.append_section(None, _s3)
 
+        _copy_content = Adw.ButtonContent()
+        _copy_content.set_icon_name('edit-copy-symbolic')
+        _copy_content.set_label('Copy')
+
         copy_menu_btn = Gtk.MenuButton()
         copy_menu_btn.add_css_class('flat')
-        copy_menu_btn.set_icon_name('edit-copy-symbolic')
-        copy_menu_btn.set_tooltip_text('Copy')
+        copy_menu_btn.set_child(_copy_content)
         copy_menu_btn.set_menu_model(_copy_menu)
 
         self._explain_analyze_warning = Gtk.Label()
@@ -573,7 +576,6 @@ class SqlEditor(Gtk.Box):
         self._explain_analyze_warning.add_css_class('warning')
         self._explain_analyze_warning.set_label('⚠ EXPLAIN ANALYZE executed the query')
         self._explain_analyze_warning.set_visible(False)
-        self._explain_analyze_warning.set_hexpand(True)
         self._explain_analyze_warning.set_xalign(0)
         self._explain_analyze_warning.set_margin_start(8)
 
@@ -621,7 +623,11 @@ class SqlEditor(Gtk.Box):
         explain_toolbar.set_margin_end(6)
         explain_toolbar.set_margin_top(4)
         explain_toolbar.set_margin_bottom(4)
+        _toolbar_spacer = Gtk.Box()
+        _toolbar_spacer.set_hexpand(True)
+
         explain_toolbar.append(explain_view_switcher)
+        explain_toolbar.append(_toolbar_spacer)
         explain_toolbar.append(self._explain_analyze_warning)
         explain_toolbar.append(self._explain_copy_confirm)
         explain_toolbar.append(copy_menu_btn)

--- a/src/sql_editor.py
+++ b/src/sql_editor.py
@@ -566,10 +566,11 @@ class SqlEditor(Gtk.Box):
         _copy_content.set_icon_name('edit-copy-symbolic')
         _copy_content.set_label('Copy')
 
-        copy_menu_btn = Gtk.MenuButton()
-        copy_menu_btn.add_css_class('flat')
-        copy_menu_btn.set_child(_copy_content)
-        copy_menu_btn.set_menu_model(_copy_menu)
+        self._explain_copy_btn = Adw.SplitButton()
+        self._explain_copy_btn.add_css_class('flat')
+        self._explain_copy_btn.set_child(_copy_content)
+        self._explain_copy_btn.set_menu_model(_copy_menu)
+        self._explain_copy_btn.set_action_name('explain-copy.copy-text')
 
         self._explain_analyze_warning = Gtk.Label()
         self._explain_analyze_warning.add_css_class('caption')
@@ -630,7 +631,7 @@ class SqlEditor(Gtk.Box):
         explain_toolbar.append(_toolbar_spacer)
         explain_toolbar.append(self._explain_analyze_warning)
         explain_toolbar.append(self._explain_copy_confirm)
-        explain_toolbar.append(copy_menu_btn)
+        explain_toolbar.append(self._explain_copy_btn)
 
         explain_outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         explain_outer.append(explain_toolbar)
@@ -1375,6 +1376,7 @@ class SqlEditor(Gtk.Box):
         self._explain_text_buf.set_text(plan_text)
         self._explain_analyze_warning.set_visible(is_analyze)
         self._explain_view_stack.set_visible_child_name('text')
+        self._explain_copy_btn.set_action_name('explain-copy.copy-text')
         self._explain_copy_text_action.set_enabled(True)
         self._explain_copy_json_action.set_enabled(True)
         self._results_stack.set_visible_child_name('explain')
@@ -1520,6 +1522,11 @@ class SqlEditor(Gtk.Box):
 
     def _on_explain_view_changed(self, stack, _pspec):
         page_name = stack.get_visible_child_name()
+        self._explain_copy_btn.set_action_name({
+            'text':  'explain-copy.copy-text',
+            'tree':  'explain-copy.copy-markdown',
+            'graph': 'explain-copy.copy-png',
+        }.get(page_name, 'explain-copy.copy-text'))
         if page_name == 'text':
             return
 

--- a/src/sql_editor.py
+++ b/src/sql_editor.py
@@ -14,6 +14,7 @@ gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, GObject, GLib, Gdk, Gio
 
 from data_grid import make_column_view
+from explain_graph import ExplainGraph
 
 _HISTORY_LIMIT = 50
 
@@ -531,6 +532,11 @@ class SqlEditor(Gtk.Box):
         self._explain_tree_toggle.set_icon_name('view-list-tree-symbolic')
         self._explain_tree_toggle.connect('toggled', self._on_explain_tree_toggled)
 
+        self._explain_graph_toggle = Gtk.ToggleButton(label='Graph')
+        self._explain_graph_toggle.add_css_class('flat')
+        self._explain_graph_toggle.set_icon_name('preferences-system-network-symbolic')
+        self._explain_graph_toggle.connect('toggled', self._on_explain_graph_toggled)
+
         self._explain_analyze_warning = Gtk.Label()
         self._explain_analyze_warning.add_css_class('caption')
         self._explain_analyze_warning.add_css_class('warning')
@@ -548,6 +554,7 @@ class SqlEditor(Gtk.Box):
         explain_toolbar.append(copy_text_btn)
         explain_toolbar.append(copy_json_btn)
         explain_toolbar.append(self._explain_tree_toggle)
+        explain_toolbar.append(self._explain_graph_toggle)
         explain_toolbar.append(self._explain_analyze_warning)
         explain_toolbar.append(self._explain_copy_confirm)
 
@@ -569,9 +576,18 @@ class SqlEditor(Gtk.Box):
         self._explain_tree_scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self._explain_tree_scroll.set_vexpand(True)
 
+        self._explain_graph = ExplainGraph()
+        self._explain_graph.set_vexpand(True)
+        self._explain_graph.set_hexpand(True)
+        self._explain_graph_scroll = Gtk.ScrolledWindow()
+        self._explain_graph_scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        self._explain_graph_scroll.set_vexpand(True)
+        self._explain_graph_scroll.set_child(self._explain_graph)
+
         self._explain_inner_stack = Gtk.Stack()
         self._explain_inner_stack.add_named(explain_text_scroll, 'text')
         self._explain_inner_stack.add_named(self._explain_tree_scroll, 'tree')
+        self._explain_inner_stack.add_named(self._explain_graph_scroll, 'graph')
 
         explain_outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         explain_outer.append(explain_toolbar)
@@ -1271,6 +1287,7 @@ class SqlEditor(Gtk.Box):
         self._explain_is_analyze = (mode == 'analyze')
         self._explain_json_cache = None
         self._explain_tree_toggle.set_active(False)
+        self._explain_graph_toggle.set_active(False)
         self._start_run(sql, explain_mode=mode)
 
     def _execute_explain(self, conn, sql, mode):
@@ -1375,22 +1392,14 @@ class SqlEditor(Gtk.Box):
         self._explain_copy_confirm_timer = 0
         return False
 
-    def _on_explain_tree_toggled(self, btn):
-        if not btn.get_active():
-            self._explain_inner_stack.set_visible_child_name('text')
-            return
-
-        if self._explain_json_cache is not None:
-            self._render_explain_tree(self._explain_json_cache)
-            return
-
-        conn = self._explain_last_conn
-        sql = self._explain_last_sql
+    def _fetch_explain_json(self, on_success, on_error):
+        """Fetch EXPLAIN JSON in a background thread, calling callbacks on the main thread."""
+        conn       = self._explain_last_conn
+        sql        = self._explain_last_sql
         is_analyze = self._explain_is_analyze
         if not conn or not sql:
-            btn.set_active(False)
+            on_error('No plan to fetch')
             return
-
         prefix = 'EXPLAIN (ANALYZE, FORMAT JSON)' if is_analyze else 'EXPLAIN (FORMAT JSON)'
 
         def run():
@@ -1408,12 +1417,57 @@ class SqlEditor(Gtk.Box):
                         plan_json = rows[0][0] if rows else []
                     db.rollback()
                 self._explain_json_cache = plan_json
-                GLib.idle_add(self._render_explain_tree, plan_json)
+                GLib.idle_add(on_success, plan_json)
             except Exception as e:
-                GLib.idle_add(self._explain_tree_toggle.set_active, False)
-                GLib.idle_add(self._show_explain_copy_confirm, f'Tree error: {e}')
+                GLib.idle_add(on_error, str(e))
 
         threading.Thread(target=run, daemon=True).start()
+
+    def _on_explain_tree_toggled(self, btn):
+        if not btn.get_active():
+            if not self._explain_graph_toggle.get_active():
+                self._explain_inner_stack.set_visible_child_name('text')
+            return
+        self._explain_graph_toggle.set_active(False)
+
+        if self._explain_json_cache is not None:
+            self._render_explain_tree(self._explain_json_cache)
+            return
+
+        if not self._explain_last_conn or not self._explain_last_sql:
+            btn.set_active(False)
+            return
+
+        self._fetch_explain_json(
+            on_success=self._render_explain_tree,
+            on_error=lambda e: (
+                self._explain_tree_toggle.set_active(False),
+                self._show_explain_copy_confirm(f'Tree error: {e}'),
+            ),
+        )
+
+    def _on_explain_graph_toggled(self, btn):
+        if not btn.get_active():
+            if not self._explain_tree_toggle.get_active():
+                self._explain_inner_stack.set_visible_child_name('text')
+            return
+        self._explain_tree_toggle.set_active(False)
+
+        if self._explain_json_cache is not None:
+            self._render_explain_graph(self._explain_json_cache)
+            return
+
+        if not self._explain_last_conn or not self._explain_last_sql:
+            btn.set_active(False)
+            return
+
+        self._fetch_explain_json(
+            on_success=self._render_explain_graph,
+            on_error=lambda e: (
+                self._explain_graph_toggle.set_active(False),
+                self._show_explain_copy_confirm(f'Graph error: {e}'),
+            ),
+        )
 
     def _render_explain_tree(self, plan_json):
         # plan_json is a list; first element has a "Plan" key
@@ -1468,6 +1522,10 @@ class SqlEditor(Gtk.Box):
 
         self._explain_tree_scroll.set_child(page)
         self._explain_inner_stack.set_visible_child_name('tree')
+
+    def _render_explain_graph(self, plan_json):
+        self._explain_graph.set_plan(plan_json)
+        self._explain_inner_stack.set_visible_child_name('graph')
 
     # ── History ───────────────────────────────────────────────────────────────
 

--- a/src/sql_editor.py
+++ b/src/sql_editor.py
@@ -1463,8 +1463,8 @@ class SqlEditor(Gtk.Box):
             png = self._explain_graph.render_to_png_bytes()
             if not png:
                 return
-            texture = Gdk.Texture.new_from_bytes(GLib.Bytes.new(png))
-            Gdk.Display.get_default().get_clipboard().set(texture)
+            provider = Gdk.ContentProvider.new_for_bytes('image/png', GLib.Bytes.new(png))
+            Gdk.Display.get_default().get_clipboard().set_content(provider)
             self._show_explain_copy_confirm('Copied PNG')
         except Exception as e:
             self._show_explain_copy_confirm(f'PNG error: {e}')
@@ -1474,7 +1474,8 @@ class SqlEditor(Gtk.Box):
             svg = self._explain_graph.render_to_svg_bytes()
             if not svg:
                 return
-            Gdk.Display.get_default().get_clipboard().set(svg.decode('utf-8'))
+            provider = Gdk.ContentProvider.new_for_bytes('image/svg+xml', GLib.Bytes.new(svg))
+            Gdk.Display.get_default().get_clipboard().set_content(provider)
             self._show_explain_copy_confirm('Copied SVG')
         except Exception as e:
             self._show_explain_copy_confirm(f'SVG error: {e}')

--- a/src/sql_editor.py
+++ b/src/sql_editor.py
@@ -1492,7 +1492,7 @@ class SqlEditor(Gtk.Box):
         self._explain_copy_confirm_timer = 0
         return False
 
-    def _fetch_explain_json(self, on_success, on_error):
+    def _fetch_explain_json(self, on_error):
         """Fetch EXPLAIN JSON in a background thread, calling callbacks on the main thread."""
         conn       = self._explain_last_conn
         sql        = self._explain_last_sql
@@ -1519,7 +1519,6 @@ class SqlEditor(Gtk.Box):
                     db.rollback()
                 self._explain_json_cache = plan_json
                 self._explain_fetching = False
-                GLib.idle_add(on_success, plan_json)
                 GLib.idle_add(self._refresh_current_explain_view)
             except Exception as e:
                 self._explain_fetching = False
@@ -1555,11 +1554,11 @@ class SqlEditor(Gtk.Box):
             if self._explain_fetching:
                 return
             self._fetch_explain_json(
-                on_success=self._render_explain_tree,
                 on_error=lambda e: (
                     stack.set_visible_child_name('text'),
                     self._show_explain_copy_confirm(f'Tree error: {e}'),
-                ),
+                    False,
+                )[-1],
             )
 
         elif page_name == 'graph':
@@ -1572,11 +1571,11 @@ class SqlEditor(Gtk.Box):
             if self._explain_fetching:
                 return
             self._fetch_explain_json(
-                on_success=self._render_explain_graph,
                 on_error=lambda e: (
                     stack.set_visible_child_name('text'),
                     self._show_explain_copy_confirm(f'Graph error: {e}'),
-                ),
+                    False,
+                )[-1],
             )
 
     def _render_explain_tree(self, plan_json):

--- a/src/sql_editor.py
+++ b/src/sql_editor.py
@@ -322,6 +322,9 @@ class SqlEditor(Gtk.Box):
         self._explain_last_conn = None
         self._explain_is_analyze = False
         self._explain_json_cache = None
+        self._explain_fetching = False
+        self._explain_tree_rendered = False
+        self._explain_graph_rendered = False
         self._build_ui()
         self._load_file()
         self.connect('destroy', self._on_destroy)
@@ -527,16 +530,6 @@ class SqlEditor(Gtk.Box):
         copy_json_btn.set_icon_name('edit-copy-symbolic')
         copy_json_btn.connect('clicked', self._on_explain_copy_json)
 
-        self._explain_tree_toggle = Gtk.ToggleButton(label='Tree')
-        self._explain_tree_toggle.add_css_class('flat')
-        self._explain_tree_toggle.set_icon_name('view-list-tree-symbolic')
-        self._explain_tree_toggle.connect('toggled', self._on_explain_tree_toggled)
-
-        self._explain_graph_toggle = Gtk.ToggleButton(label='Graph')
-        self._explain_graph_toggle.add_css_class('flat')
-        self._explain_graph_toggle.set_icon_name('preferences-system-network-symbolic')
-        self._explain_graph_toggle.connect('toggled', self._on_explain_graph_toggled)
-
         self._explain_analyze_warning = Gtk.Label()
         self._explain_analyze_warning.add_css_class('caption')
         self._explain_analyze_warning.add_css_class('warning')
@@ -545,18 +538,6 @@ class SqlEditor(Gtk.Box):
         self._explain_analyze_warning.set_hexpand(True)
         self._explain_analyze_warning.set_xalign(0)
         self._explain_analyze_warning.set_margin_start(8)
-
-        explain_toolbar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
-        explain_toolbar.set_margin_start(6)
-        explain_toolbar.set_margin_end(6)
-        explain_toolbar.set_margin_top(4)
-        explain_toolbar.set_margin_bottom(4)
-        explain_toolbar.append(copy_text_btn)
-        explain_toolbar.append(copy_json_btn)
-        explain_toolbar.append(self._explain_tree_toggle)
-        explain_toolbar.append(self._explain_graph_toggle)
-        explain_toolbar.append(self._explain_analyze_warning)
-        explain_toolbar.append(self._explain_copy_confirm)
 
         self._explain_text_buf = Gtk.TextBuffer()
         self._explain_text_view = Gtk.TextView(buffer=self._explain_text_buf)
@@ -584,15 +565,34 @@ class SqlEditor(Gtk.Box):
         self._explain_graph_scroll.set_vexpand(True)
         self._explain_graph_scroll.set_child(self._explain_graph)
 
-        self._explain_inner_stack = Gtk.Stack()
-        self._explain_inner_stack.add_named(explain_text_scroll, 'text')
-        self._explain_inner_stack.add_named(self._explain_tree_scroll, 'tree')
-        self._explain_inner_stack.add_named(self._explain_graph_scroll, 'graph')
+        self._explain_view_stack = Adw.ViewStack()
+        self._explain_view_stack.add_titled_with_icon(
+            explain_text_scroll, 'text', 'Text', 'format-text-plaintext-symbolic')
+        self._explain_view_stack.add_titled_with_icon(
+            self._explain_tree_scroll, 'tree', 'Tree', 'view-list-tree-symbolic')
+        self._explain_view_stack.add_titled_with_icon(
+            self._explain_graph_scroll, 'graph', 'Graph', 'preferences-system-network-symbolic')
+        self._explain_view_stack.connect('notify::visible-child', self._on_explain_view_changed)
+
+        explain_view_switcher = Adw.ViewSwitcher()
+        explain_view_switcher.set_stack(self._explain_view_stack)
+        explain_view_switcher.set_policy(Adw.ViewSwitcherPolicy.WIDE)
+
+        explain_toolbar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
+        explain_toolbar.set_margin_start(6)
+        explain_toolbar.set_margin_end(6)
+        explain_toolbar.set_margin_top(4)
+        explain_toolbar.set_margin_bottom(4)
+        explain_toolbar.append(copy_text_btn)
+        explain_toolbar.append(copy_json_btn)
+        explain_toolbar.append(explain_view_switcher)
+        explain_toolbar.append(self._explain_analyze_warning)
+        explain_toolbar.append(self._explain_copy_confirm)
 
         explain_outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         explain_outer.append(explain_toolbar)
         explain_outer.append(Gtk.Separator())
-        explain_outer.append(self._explain_inner_stack)
+        explain_outer.append(self._explain_view_stack)
         self._results_stack.add_named(explain_outer, 'explain')
 
         # Tab view — "Results" is always the first (pinned) tab;
@@ -1286,8 +1286,9 @@ class SqlEditor(Gtk.Box):
         self._explain_last_conn = dict(self._connection)
         self._explain_is_analyze = (mode == 'analyze')
         self._explain_json_cache = None
-        self._explain_tree_toggle.set_active(False)
-        self._explain_graph_toggle.set_active(False)
+        self._explain_fetching = False
+        self._explain_tree_rendered = False
+        self._explain_graph_rendered = False
         self._start_run(sql, explain_mode=mode)
 
     def _execute_explain(self, conn, sql, mode):
@@ -1325,7 +1326,7 @@ class SqlEditor(Gtk.Box):
         self._finish_run()
         self._explain_text_buf.set_text(plan_text)
         self._explain_analyze_warning.set_visible(is_analyze)
-        self._explain_inner_stack.set_visible_child_name('text')
+        self._explain_view_stack.set_visible_child_name('text')
         self._results_stack.set_visible_child_name('explain')
         self._results_meta.set_label(f'{"EXPLAIN ANALYZE" if is_analyze else "EXPLAIN"} — {self._elapsed_ms()} ms')
         self._append_history(
@@ -1401,6 +1402,7 @@ class SqlEditor(Gtk.Box):
             on_error('No plan to fetch')
             return
         prefix = 'EXPLAIN (ANALYZE, FORMAT JSON)' if is_analyze else 'EXPLAIN (FORMAT JSON)'
+        self._explain_fetching = True
 
         def run():
             try:
@@ -1417,59 +1419,56 @@ class SqlEditor(Gtk.Box):
                         plan_json = rows[0][0] if rows else []
                     db.rollback()
                 self._explain_json_cache = plan_json
+                self._explain_fetching = False
                 GLib.idle_add(on_success, plan_json)
             except Exception as e:
+                self._explain_fetching = False
                 GLib.idle_add(on_error, str(e))
 
         threading.Thread(target=run, daemon=True).start()
 
-    def _on_explain_tree_toggled(self, btn):
-        if not btn.get_active():
-            if not self._explain_graph_toggle.get_active():
-                self._explain_inner_stack.set_visible_child_name('text')
-            return
-        self._explain_graph_toggle.set_active(False)
-
-        if self._explain_json_cache is not None:
-            self._render_explain_tree(self._explain_json_cache)
+    def _on_explain_view_changed(self, stack, _pspec):
+        page_name = stack.get_visible_child_name()
+        if page_name == 'text':
             return
 
-        if not self._explain_last_conn or not self._explain_last_sql:
-            btn.set_active(False)
-            return
+        if page_name == 'tree':
+            if self._explain_json_cache is not None:
+                self._render_explain_tree(self._explain_json_cache)
+                return
+            if not self._explain_last_conn or not self._explain_last_sql:
+                stack.set_visible_child_name('text')
+                return
+            if self._explain_fetching:
+                return
+            self._fetch_explain_json(
+                on_success=self._render_explain_tree,
+                on_error=lambda e: (
+                    stack.set_visible_child_name('text'),
+                    self._show_explain_copy_confirm(f'Tree error: {e}'),
+                ),
+            )
 
-        self._fetch_explain_json(
-            on_success=self._render_explain_tree,
-            on_error=lambda e: (
-                self._explain_tree_toggle.set_active(False),
-                self._show_explain_copy_confirm(f'Tree error: {e}'),
-            ),
-        )
-
-    def _on_explain_graph_toggled(self, btn):
-        if not btn.get_active():
-            if not self._explain_tree_toggle.get_active():
-                self._explain_inner_stack.set_visible_child_name('text')
-            return
-        self._explain_tree_toggle.set_active(False)
-
-        if self._explain_json_cache is not None:
-            self._render_explain_graph(self._explain_json_cache)
-            return
-
-        if not self._explain_last_conn or not self._explain_last_sql:
-            btn.set_active(False)
-            return
-
-        self._fetch_explain_json(
-            on_success=self._render_explain_graph,
-            on_error=lambda e: (
-                self._explain_graph_toggle.set_active(False),
-                self._show_explain_copy_confirm(f'Graph error: {e}'),
-            ),
-        )
+        elif page_name == 'graph':
+            if self._explain_json_cache is not None:
+                self._render_explain_graph(self._explain_json_cache)
+                return
+            if not self._explain_last_conn or not self._explain_last_sql:
+                stack.set_visible_child_name('text')
+                return
+            if self._explain_fetching:
+                return
+            self._fetch_explain_json(
+                on_success=self._render_explain_graph,
+                on_error=lambda e: (
+                    stack.set_visible_child_name('text'),
+                    self._show_explain_copy_confirm(f'Graph error: {e}'),
+                ),
+            )
 
     def _render_explain_tree(self, plan_json):
+        if self._explain_tree_rendered:
+            return
         # plan_json is a list; first element has a "Plan" key
         if not plan_json or not isinstance(plan_json, list):
             return
@@ -1521,11 +1520,13 @@ class SqlEditor(Gtk.Box):
         page.add(group)
 
         self._explain_tree_scroll.set_child(page)
-        self._explain_inner_stack.set_visible_child_name('tree')
+        self._explain_tree_rendered = True
 
     def _render_explain_graph(self, plan_json):
+        if self._explain_graph_rendered:
+            return
         self._explain_graph.set_plan(plan_json)
-        self._explain_inner_stack.set_visible_child_name('graph')
+        self._explain_graph_rendered = True
 
     # ── History ───────────────────────────────────────────────────────────────
 

--- a/src/sql_editor.py
+++ b/src/sql_editor.py
@@ -1459,19 +1459,25 @@ class SqlEditor(Gtk.Box):
         threading.Thread(target=run, daemon=True).start()
 
     def _on_explain_copy_png(self, _action, _param):
-        png = self._explain_graph.render_to_png_bytes()
-        if not png:
-            return
-        texture = Gdk.Texture.new_from_bytes(GLib.Bytes.new(png))
-        Gdk.Display.get_default().get_clipboard().set(texture)
-        self._show_explain_copy_confirm('Copied PNG')
+        try:
+            png = self._explain_graph.render_to_png_bytes()
+            if not png:
+                return
+            texture = Gdk.Texture.new_from_bytes(GLib.Bytes.new(png))
+            Gdk.Display.get_default().get_clipboard().set(texture)
+            self._show_explain_copy_confirm('Copied PNG')
+        except Exception as e:
+            self._show_explain_copy_confirm(f'PNG error: {e}')
 
     def _on_explain_copy_svg(self, _action, _param):
-        svg = self._explain_graph.render_to_svg_bytes()
-        if not svg:
-            return
-        Gdk.Display.get_default().get_clipboard().set(svg.decode('utf-8'))
-        self._show_explain_copy_confirm('Copied SVG')
+        try:
+            svg = self._explain_graph.render_to_svg_bytes()
+            if not svg:
+                return
+            Gdk.Display.get_default().get_clipboard().set(svg.decode('utf-8'))
+            self._show_explain_copy_confirm('Copied SVG')
+        except Exception as e:
+            self._show_explain_copy_confirm(f'SVG error: {e}')
 
     def _show_explain_copy_confirm(self, msg):
         self._explain_copy_confirm.set_label(msg)
@@ -1514,11 +1520,20 @@ class SqlEditor(Gtk.Box):
                 self._explain_json_cache = plan_json
                 self._explain_fetching = False
                 GLib.idle_add(on_success, plan_json)
+                GLib.idle_add(self._refresh_current_explain_view)
             except Exception as e:
                 self._explain_fetching = False
                 GLib.idle_add(on_error, str(e))
 
         threading.Thread(target=run, daemon=True).start()
+
+    def _refresh_current_explain_view(self):
+        """After a fetch completes, render the currently visible tab if it still needs it."""
+        page = self._explain_view_stack.get_visible_child_name()
+        if page == 'tree' and not self._explain_tree_rendered and self._explain_json_cache:
+            self._render_explain_tree(self._explain_json_cache)
+        elif page == 'graph' and not self._explain_graph_rendered and self._explain_json_cache:
+            self._render_explain_graph(self._explain_json_cache)
 
     def _on_explain_view_changed(self, stack, _pspec):
         page_name = stack.get_visible_child_name()

--- a/src/sql_editor.py
+++ b/src/sql_editor.py
@@ -520,15 +520,53 @@ class SqlEditor(Gtk.Box):
         self._explain_copy_confirm.set_visible(False)
         self._explain_copy_confirm_timer = 0
 
-        copy_text_btn = Gtk.Button(label='Copy Text')
-        copy_text_btn.add_css_class('flat')
-        copy_text_btn.set_icon_name('edit-copy-symbolic')
-        copy_text_btn.connect('clicked', self._on_explain_copy_text)
+        # Copy action group — items enabled contextually as views are rendered
+        _copy_ag = Gio.SimpleActionGroup()
+        self._explain_copy_text_action = Gio.SimpleAction.new('copy-text', None)
+        self._explain_copy_text_action.connect('activate', self._on_explain_copy_text)
+        self._explain_copy_text_action.set_enabled(False)
+        _copy_ag.add_action(self._explain_copy_text_action)
 
-        copy_json_btn = Gtk.Button(label='Copy JSON')
-        copy_json_btn.add_css_class('flat')
-        copy_json_btn.set_icon_name('edit-copy-symbolic')
-        copy_json_btn.connect('clicked', self._on_explain_copy_json)
+        self._explain_copy_markdown_action = Gio.SimpleAction.new('copy-markdown', None)
+        self._explain_copy_markdown_action.connect('activate', self._on_explain_copy_markdown)
+        self._explain_copy_markdown_action.set_enabled(False)
+        _copy_ag.add_action(self._explain_copy_markdown_action)
+
+        self._explain_copy_json_action = Gio.SimpleAction.new('copy-json', None)
+        self._explain_copy_json_action.connect('activate', self._on_explain_copy_json)
+        self._explain_copy_json_action.set_enabled(False)
+        _copy_ag.add_action(self._explain_copy_json_action)
+
+        self._explain_copy_png_action = Gio.SimpleAction.new('copy-png', None)
+        self._explain_copy_png_action.connect('activate', self._on_explain_copy_png)
+        self._explain_copy_png_action.set_enabled(False)
+        _copy_ag.add_action(self._explain_copy_png_action)
+
+        self._explain_copy_svg_action = Gio.SimpleAction.new('copy-svg', None)
+        self._explain_copy_svg_action.connect('activate', self._on_explain_copy_svg)
+        self._explain_copy_svg_action.set_enabled(False)
+        _copy_ag.add_action(self._explain_copy_svg_action)
+
+        self.insert_action_group('explain-copy', _copy_ag)
+
+        _copy_menu = Gio.Menu()
+        _s1 = Gio.Menu()
+        _s1.append('Copy Text', 'explain-copy.copy-text')
+        _s1.append('Copy Markdown', 'explain-copy.copy-markdown')
+        _copy_menu.append_section(None, _s1)
+        _s2 = Gio.Menu()
+        _s2.append('Copy JSON', 'explain-copy.copy-json')
+        _copy_menu.append_section(None, _s2)
+        _s3 = Gio.Menu()
+        _s3.append('Copy PNG', 'explain-copy.copy-png')
+        _s3.append('Copy SVG', 'explain-copy.copy-svg')
+        _copy_menu.append_section(None, _s3)
+
+        copy_menu_btn = Gtk.MenuButton()
+        copy_menu_btn.add_css_class('flat')
+        copy_menu_btn.set_icon_name('edit-copy-symbolic')
+        copy_menu_btn.set_tooltip_text('Copy')
+        copy_menu_btn.set_menu_model(_copy_menu)
 
         self._explain_analyze_warning = Gtk.Label()
         self._explain_analyze_warning.add_css_class('caption')
@@ -583,11 +621,10 @@ class SqlEditor(Gtk.Box):
         explain_toolbar.set_margin_end(6)
         explain_toolbar.set_margin_top(4)
         explain_toolbar.set_margin_bottom(4)
-        explain_toolbar.append(copy_text_btn)
-        explain_toolbar.append(copy_json_btn)
         explain_toolbar.append(explain_view_switcher)
         explain_toolbar.append(self._explain_analyze_warning)
         explain_toolbar.append(self._explain_copy_confirm)
+        explain_toolbar.append(copy_menu_btn)
 
         explain_outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         explain_outer.append(explain_toolbar)
@@ -1289,6 +1326,11 @@ class SqlEditor(Gtk.Box):
         self._explain_fetching = False
         self._explain_tree_rendered = False
         self._explain_graph_rendered = False
+        self._explain_copy_text_action.set_enabled(False)
+        self._explain_copy_markdown_action.set_enabled(False)
+        self._explain_copy_json_action.set_enabled(False)
+        self._explain_copy_png_action.set_enabled(False)
+        self._explain_copy_svg_action.set_enabled(False)
         self._start_run(sql, explain_mode=mode)
 
     def _execute_explain(self, conn, sql, mode):
@@ -1327,6 +1369,8 @@ class SqlEditor(Gtk.Box):
         self._explain_text_buf.set_text(plan_text)
         self._explain_analyze_warning.set_visible(is_analyze)
         self._explain_view_stack.set_visible_child_name('text')
+        self._explain_copy_text_action.set_enabled(True)
+        self._explain_copy_json_action.set_enabled(True)
         self._results_stack.set_visible_child_name('explain')
         self._results_meta.set_label(f'{"EXPLAIN ANALYZE" if is_analyze else "EXPLAIN"} — {self._elapsed_ms()} ms')
         self._append_history(
@@ -1334,14 +1378,40 @@ class SqlEditor(Gtk.Box):
             self._elapsed_ms(),
         )
 
-    def _on_explain_copy_text(self, _btn):
+    def _on_explain_copy_text(self, _action, _param):
         start = self._explain_text_buf.get_start_iter()
         end = self._explain_text_buf.get_end_iter()
         text = self._explain_text_buf.get_text(start, end, False)
         Gdk.Display.get_default().get_clipboard().set(text)
         self._show_explain_copy_confirm('Copied')
 
-    def _on_explain_copy_json(self, _btn):
+    def _on_explain_copy_markdown(self, _action, _param):
+        if self._explain_json_cache is None:
+            return
+        plan = self._explain_json_cache[0].get('Plan', {})
+        lines = []
+        def _walk(node, depth):
+            indent = '  ' * depth
+            node_type = node.get('Node Type', '?')
+            cost = node.get('Total Cost', 0.0)
+            plan_rows = node.get('Plan Rows', '?')
+            parts = [f'cost={cost:.2f}', f'rows≈{plan_rows}']
+            actual_rows = node.get('Actual Rows')
+            actual_time = node.get('Actual Total Time')
+            if actual_rows is not None:
+                parts.append(f'actual={actual_rows}')
+            if actual_time is not None:
+                parts.append(f'{actual_time:.2f}ms')
+            relation = node.get('Relation Name', '')
+            title = f'{node_type} on {relation}' if relation else node_type
+            lines.append(f'{indent}- **{title}** ({", ".join(parts)})')
+            for child in node.get('Plans', []):
+                _walk(child, depth + 1)
+        _walk(plan, 0)
+        Gdk.Display.get_default().get_clipboard().set('\n'.join(lines))
+        self._show_explain_copy_confirm('Copied Markdown')
+
+    def _on_explain_copy_json(self, _action, _param):
         if self._explain_json_cache is not None:
             Gdk.Display.get_default().get_clipboard().set(
                 json.dumps(self._explain_json_cache, indent=2))
@@ -1379,6 +1449,21 @@ class SqlEditor(Gtk.Box):
                 GLib.idle_add(self._show_explain_copy_confirm, f'Error: {e}')
 
         threading.Thread(target=run, daemon=True).start()
+
+    def _on_explain_copy_png(self, _action, _param):
+        png = self._explain_graph.render_to_png_bytes()
+        if not png:
+            return
+        texture = Gdk.Texture.new_from_bytes(GLib.Bytes.new(png))
+        Gdk.Display.get_default().get_clipboard().set(texture)
+        self._show_explain_copy_confirm('Copied PNG')
+
+    def _on_explain_copy_svg(self, _action, _param):
+        svg = self._explain_graph.render_to_svg_bytes()
+        if not svg:
+            return
+        Gdk.Display.get_default().get_clipboard().set(svg.decode('utf-8'))
+        self._show_explain_copy_confirm('Copied SVG')
 
     def _show_explain_copy_confirm(self, msg):
         self._explain_copy_confirm.set_label(msg)
@@ -1521,12 +1606,15 @@ class SqlEditor(Gtk.Box):
 
         self._explain_tree_scroll.set_child(page)
         self._explain_tree_rendered = True
+        self._explain_copy_markdown_action.set_enabled(True)
 
     def _render_explain_graph(self, plan_json):
         if self._explain_graph_rendered:
             return
         self._explain_graph.set_plan(plan_json)
         self._explain_graph_rendered = True
+        self._explain_copy_png_action.set_enabled(True)
+        self._explain_copy_svg_action.set_enabled(True)
 
     # ── History ───────────────────────────────────────────────────────────────
 

--- a/src/sql_editor.py
+++ b/src/sql_editor.py
@@ -567,7 +567,7 @@ class SqlEditor(Gtk.Box):
 
         self._explain_view_stack = Adw.ViewStack()
         self._explain_view_stack.add_titled_with_icon(
-            explain_text_scroll, 'text', 'Text', 'format-text-plaintext-symbolic')
+            explain_text_scroll, 'text', 'Text', 'view-paged-symbolic')
         self._explain_view_stack.add_titled_with_icon(
             self._explain_tree_scroll, 'tree', 'Tree', 'view-list-tree-symbolic')
         self._explain_view_stack.add_titled_with_icon(

--- a/src/sql_editor.py
+++ b/src/sql_editor.py
@@ -1425,38 +1425,20 @@ class SqlEditor(Gtk.Box):
                 json.dumps(self._explain_json_cache, indent=2))
             self._show_explain_copy_confirm('Copied JSON')
             return
-        # Re-run with FORMAT JSON
-        conn = self._explain_last_conn
-        sql = self._explain_last_sql
-        is_analyze = self._explain_is_analyze
-        if not conn or not sql:
+        if self._explain_fetching:
             return
-        prefix = 'EXPLAIN (ANALYZE, FORMAT JSON)' if is_analyze else 'EXPLAIN (FORMAT JSON)'
-
-        def run():
-            try:
-                import psycopg
-                from tunnel import open_tunnel
-                with open_tunnel(conn) as (host, port), psycopg.connect(
-                    host=host, port=port,
-                    dbname=conn['database'], user=conn['username'],
-                    password=conn['password'], connect_timeout=10,
-                ) as db:
-                    with db.cursor() as cur:
-                        cur.execute(f'{prefix} {sql}')
-                        rows = cur.fetchall()
-                        plan_json = rows[0][0] if rows else []
-                    db.rollback()
-                self._explain_json_cache = plan_json
-                text = json.dumps(plan_json, indent=2)
-                def _copy_and_confirm(t=text):
-                    Gdk.Display.get_default().get_clipboard().set(t)
-                    self._show_explain_copy_confirm('Copied JSON')
-                GLib.idle_add(_copy_and_confirm)
-            except Exception as e:
-                GLib.idle_add(self._show_explain_copy_confirm, f'Error: {e}')
-
-        threading.Thread(target=run, daemon=True).start()
+        def _copy_after_fetch():
+            if self._explain_json_cache is not None:
+                Gdk.Display.get_default().get_clipboard().set(
+                    json.dumps(self._explain_json_cache, indent=2))
+                self._show_explain_copy_confirm('Copied JSON')
+        self._fetch_explain_json(
+            on_error=lambda e: (
+                self._show_explain_copy_confirm(f'Error: {e}'),
+                False,
+            )[-1],
+            on_complete=_copy_after_fetch,
+        )
 
     def _on_explain_copy_png(self, _action, _param):
         try:
@@ -1493,7 +1475,7 @@ class SqlEditor(Gtk.Box):
         self._explain_copy_confirm_timer = 0
         return False
 
-    def _fetch_explain_json(self, on_error):
+    def _fetch_explain_json(self, on_error, on_complete=None):
         """Fetch EXPLAIN JSON in a background thread, calling callbacks on the main thread."""
         conn       = self._explain_last_conn
         sql        = self._explain_last_sql
@@ -1521,6 +1503,8 @@ class SqlEditor(Gtk.Box):
                 self._explain_json_cache = plan_json
                 self._explain_fetching = False
                 GLib.idle_add(self._refresh_current_explain_view)
+                if on_complete:
+                    GLib.idle_add(on_complete)
             except Exception as e:
                 self._explain_fetching = False
                 GLib.idle_add(on_error, str(e))


### PR DESCRIPTION
## Summary
- Adds a Cairo-rendered graph view for EXPLAIN plans (`ExplainGraph` widget) showing nodes colour-coded by relative cost with bezier edges
- Replaces the old Text/Tree toggle buttons with an `Adw.ViewSwitcher` (Text | Tree | Graph sub-tabs) for discoverable navigation
- Adds an `Adw.SplitButton` Copy menu supporting Copy Text, Markdown, JSON, PNG, and SVG — primary action follows the active tab

## Issues
Closes #254

## Test plan
- [ ] Run EXPLAIN on a query — results panel shows Text tab with plan output
- [ ] Switch to Tree tab — expandable node tree renders, expensive nodes highlighted in red
- [ ] Switch to Graph tab — Cairo graph renders with cost-heatmap colours and bezier edges
- [ ] Switch back to Text — works without navigating away first
- [ ] Copy button: left-click copies the tab-appropriate format (Text/Markdown/PNG per tab)
- [ ] Copy button: arrow opens dropdown with all 5 formats; disabled items are greyed out
- [ ] Run a second EXPLAIN — all copy actions reset, view returns to Text
- [ ] Switch to Tree while a fetch is in-flight, then switch to Graph — graph renders when fetch completes