### PR TITLE
feat(#292): connection model migration — v2 schema with cloud, tags, and identity fields

### DIFF
--- a/src/connections.py
+++ b/src/connections.py
@@ -35,6 +35,21 @@ def _ssh_key(conn_id):
     return f'{conn_id}:ssh'
 
 
+def _write_connections_file(connections, tags_registry):
+    tmp = CONNECTIONS_FILE + '.tmp'
+    with open(tmp, 'w') as f:
+        json.dump(
+            {
+                'schema_version': SCHEMA_VERSION,
+                'connections': connections,
+                'tags': tags_registry,
+            },
+            f,
+            indent=2,
+        )
+    os.replace(tmp, CONNECTIONS_FILE)
+
+
 def _apply_defaults(conn, tags_registry):
     """Add any missing new fields to a connection dict in-place."""
     if 'id' not in conn:
@@ -84,24 +99,11 @@ class ConnectionStore:
         tags_registry = {}
         for conn in old_list:
             _apply_defaults(conn, tags_registry)
-        self._connections = old_list
-        self._tags_registry = tags_registry
-        self._save()
+        _write_connections_file(old_list, tags_registry)
         return old_list, tags_registry
 
     def _save(self):
-        tmp = CONNECTIONS_FILE + '.tmp'
-        with open(tmp, 'w') as f:
-            json.dump(
-                {
-                    'schema_version': SCHEMA_VERSION,
-                    'connections': self._connections,
-                    'tags': self._tags_registry,
-                },
-                f,
-                indent=2,
-            )
-        os.replace(tmp, CONNECTIONS_FILE)
+        _write_connections_file(self._connections, self._tags_registry)
 
     def get_tags_registry(self):
         return dict(self._tags_registry)
@@ -130,8 +132,7 @@ class ConnectionStore:
             raise KeyringUnavailableError(str(e)) from e
 
     def add(self, conn):
-        if 'id' not in conn:
-            conn['id'] = str(uuid.uuid4())
+        _apply_defaults(conn, self._tags_registry)
         password = conn.pop('password', '')
         ssh_passphrase = conn.pop('ssh_passphrase', '')
         try:
@@ -145,8 +146,7 @@ class ConnectionStore:
 
     def add_after(self, after_id, conn):
         """Like add(), but inserts the new connection immediately after after_id."""
-        if 'id' not in conn:
-            conn['id'] = str(uuid.uuid4())
+        _apply_defaults(conn, self._tags_registry)
         password = conn.pop('password', '')
         ssh_passphrase = conn.pop('ssh_passphrase', '')
         try:

--- a/src/connections.py
+++ b/src/connections.py
@@ -60,16 +60,18 @@ def _apply_defaults(conn, tags_registry):
     # Convert legacy folder field to a tag
     if 'folder' in conn:
         folder = conn.pop('folder')
-        if folder and folder not in conn['tags']:
-            conn['tags'].append(folder)
+        if folder:
             tags_registry.setdefault(folder, {'color': '#aaaaaa', 'warn_on_connect': False})
+            if folder not in conn['tags']:
+                conn['tags'].append(folder)
     # Convert legacy environment/environment_color fields to a tag
     if 'environment' in conn:
         env = conn.pop('environment')
         color = conn.pop('environment_color', '#aaaaaa') or '#aaaaaa'
-        if env and env not in conn['tags']:
-            conn['tags'].append(env)
+        if env:
             tags_registry.setdefault(env, {'color': color, 'warn_on_connect': False})
+            if env not in conn['tags']:
+                conn['tags'].append(env)
     elif 'environment_color' in conn:
         conn.pop('environment_color')
 
@@ -190,9 +192,13 @@ class ConnectionStore:
             raise KeyringUnavailableError(str(e)) from e
         for i, c in enumerate(self._connections):
             if c['id'] == conn['id']:
-                self._connections[i] = conn
+                merged = {**c, **conn}
+                _apply_defaults(merged, self._tags_registry)
+                self._connections[i] = merged
+                conn = merged
                 break
         self._save()
+        return conn
 
 
 class FavouritesStore:

--- a/src/connections.py
+++ b/src/connections.py
@@ -9,6 +9,23 @@ CONNECTIONS_FILE = os.path.join(CONFIG_DIR, 'connections.json')
 FAVOURITES_FILE = os.path.join(CONFIG_DIR, 'favourites.json')
 KEYRING_SERVICE = 'xyz.shapemachine.tusk-gnome'
 
+SCHEMA_VERSION = 2
+
+_NEW_FIELD_DEFAULTS = {
+    'tags': list,
+    'last_connected': None,
+    'ssl_mode': 'prefer',
+    'ssl_root_cert': None,
+    'cloud_provider': None,
+    'cloud_region': None,
+    'cloud_auth_mode': 'password',
+    'cloud_instance_id': None,
+    'cloud_proxy_enabled': False,
+    'cloud_proxy_port': None,
+    'secondary_endpoint': None,
+    'secondary_port': None,
+}
+
 
 class KeyringUnavailableError(Exception):
     pass
@@ -18,22 +35,84 @@ def _ssh_key(conn_id):
     return f'{conn_id}:ssh'
 
 
+def _apply_defaults(conn, tags_registry):
+    """Add any missing new fields to a connection dict in-place."""
+    if 'id' not in conn:
+        conn['id'] = str(uuid.uuid4())
+    for field, default in _NEW_FIELD_DEFAULTS.items():
+        if field not in conn:
+            conn[field] = default() if callable(default) else default
+    # Convert legacy folder field to a tag
+    if 'folder' in conn:
+        folder = conn.pop('folder')
+        if folder and folder not in conn['tags']:
+            conn['tags'].append(folder)
+            tags_registry.setdefault(folder, {'color': '#aaaaaa', 'warn_on_connect': False})
+    # Convert legacy environment/environment_color fields to a tag
+    if 'environment' in conn:
+        env = conn.pop('environment')
+        color = conn.pop('environment_color', '#aaaaaa') or '#aaaaaa'
+        if env and env not in conn['tags']:
+            conn['tags'].append(env)
+            tags_registry.setdefault(env, {'color': color, 'warn_on_connect': False})
+    elif 'environment_color' in conn:
+        conn.pop('environment_color')
+
+
 class ConnectionStore:
     def __init__(self):
         os.makedirs(CONFIG_DIR, exist_ok=True)
-        self._connections = self._load()
+        self._connections, self._tags_registry = self._load()
 
     def _load(self):
-        if os.path.exists(CONNECTIONS_FILE):
-            with open(CONNECTIONS_FILE) as f:
-                return json.load(f)
-        return []
+        if not os.path.exists(CONNECTIONS_FILE):
+            return [], {}
+        with open(CONNECTIONS_FILE) as f:
+            raw = json.load(f)
+        if isinstance(raw, list):
+            # v1 format — bare array; migrate in-place and save
+            return self._migrate_v1(raw)
+        # v2+ format
+        connections = raw.get('connections', [])
+        tags_registry = raw.get('tags', {})
+        # Still apply defaults in case new fields were added since last write
+        for conn in connections:
+            _apply_defaults(conn, tags_registry)
+        return connections, tags_registry
+
+    def _migrate_v1(self, old_list):
+        tags_registry = {}
+        for conn in old_list:
+            _apply_defaults(conn, tags_registry)
+        self._connections = old_list
+        self._tags_registry = tags_registry
+        self._save()
+        return old_list, tags_registry
 
     def _save(self):
         tmp = CONNECTIONS_FILE + '.tmp'
         with open(tmp, 'w') as f:
-            json.dump(self._connections, f, indent=2)
+            json.dump(
+                {
+                    'schema_version': SCHEMA_VERSION,
+                    'connections': self._connections,
+                    'tags': self._tags_registry,
+                },
+                f,
+                indent=2,
+            )
         os.replace(tmp, CONNECTIONS_FILE)
+
+    def get_tags_registry(self):
+        return dict(self._tags_registry)
+
+    def set_tag(self, name, color, warn_on_connect):
+        self._tags_registry[name] = {'color': color, 'warn_on_connect': warn_on_connect}
+        self._save()
+
+    def remove_tag(self, name):
+        self._tags_registry.pop(name, None)
+        self._save()
 
     def list(self):
         return list(self._connections)

--- a/src/window.py
+++ b/src/window.py
@@ -838,7 +838,7 @@ class TuskWindow(Adw.ApplicationWindow):
 
     def _on_connection_updated(self, _dlg, conn, old_row):
         try:
-            self._store.update(conn)
+            conn = self._store.update(conn)
         except KeyringUnavailableError as e:
             self._show_keyring_error(str(e))
             return


### PR DESCRIPTION
## Summary
- Migrates connections.json from a bare JSON array to a versioned wrapper (schema_version: 2) with a top-level tags registry
- Adds 13 new per-connection fields (id, tags, last_connected, ssl_mode, cloud_*, secondary_endpoint/port) with safe defaults; all opt-in
- Auto-migrates legacy folder/environment/environment_color fields to tags on first load; migration is idempotent

## Issues
Closes #292

## Test plan
- [ ] Start app with an existing v1 connections.json (bare array) — verify it's rewritten as v2 with schema_version: 2 and all new fields present
- [ ] Start app with no connections.json — verify empty file is not created and a fresh connection added via the dialog gets all new fields
- [ ] Add a new connection — verify it has id, tags: [], ssl_mode: "prefer", cloud_provider: null, etc. in the saved file
- [ ] Start app twice with a v2 file — verify no duplicate fields, no data loss (idempotency check)
- [ ] Legacy folder field present — verify it appears as a tag after migration
- [ ] Legacy environment + environment_color present — verify converted to tag with correct color in registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)