### PR TITLE
feat: unified tags system — management, assignment, warn-on-connect (#286)

### DIFF
--- a/src/connection_dialog.py
+++ b/src/connection_dialog.py
@@ -1,3 +1,4 @@
+import re
 import threading
 import uuid
 from urllib.parse import urlparse, unquote, quote
@@ -218,7 +219,8 @@ class ConnectionDialog(Adw.Dialog):
                 # Colored swatch prefix
                 swatch = Gtk.Label()
                 swatch.set_valign(Gtk.Align.CENTER)
-                color = meta.get('color', '#aaaaaa')
+                raw_color = meta.get('color', '#aaaaaa')
+                color = raw_color if re.match(r'^#[0-9a-fA-F]{6}$', raw_color or '') else '#aaaaaa'
                 swatch.set_markup(f'<span foreground="{color}">⬤</span>')
                 row.add_prefix(swatch)
                 if meta.get('warn_on_connect'):

--- a/src/connection_dialog.py
+++ b/src/connection_dialog.py
@@ -207,10 +207,11 @@ class ConnectionDialog(Adw.Dialog):
         left_col.append(auth_group)
 
         # ── Tags ─────────────────────────────────────────────────────────────
-        tags_group = Adw.PreferencesGroup(title='Tags')
         self._tag_checks = {}  # name → Gtk.CheckButton
-        if self._store:
-            registry = self._store.get_tags_registry()
+        registry = self._store.get_tags_registry() if self._store else {}
+        tags_group = None
+        if registry:
+            tags_group = Adw.PreferencesGroup(title='Tags')
             for tag_name in sorted(registry):
                 meta = registry[tag_name]
                 row = Adw.ActionRow(title=tag_name)
@@ -238,7 +239,8 @@ class ConnectionDialog(Adw.Dialog):
         right_col = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
         right_col.set_hexpand(True)
         right_col.append(options_group)
-        right_col.append(tags_group)
+        if tags_group:
+            right_col.append(tags_group)
         right_col.append(ssh_group)
 
         two_col = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)

--- a/src/connection_dialog.py
+++ b/src/connection_dialog.py
@@ -18,7 +18,7 @@ class ConnectionDialog(Adw.Dialog):
         'connection-saved': (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,))
     }
 
-    def __init__(self, parent, connection=None, duplicate=False):
+    def __init__(self, parent, connection=None, duplicate=False, store=None):
         if duplicate:
             title = 'Duplicate Connection'
         elif connection is None:
@@ -29,6 +29,8 @@ class ConnectionDialog(Adw.Dialog):
         self._connection = connection
         self._duplicate = duplicate
         self._parent = parent
+        self._store = store
+        self._selected_tags = set(connection.get('tags', []) if connection else [])
         self._build_ui()
         if duplicate:
             self.connect('map', lambda _: self._name_row.grab_focus())
@@ -204,9 +206,35 @@ class ConnectionDialog(Adw.Dialog):
         left_col.append(details_group)
         left_col.append(auth_group)
 
+        # ── Tags ─────────────────────────────────────────────────────────────
+        tags_group = Adw.PreferencesGroup(title='Tags')
+        self._tag_rows = {}  # name → Adw.CheckRow
+        if self._store:
+            registry = self._store.get_tags_registry()
+            for tag_name in sorted(registry):
+                meta = registry[tag_name]
+                row = Adw.CheckRow(title=tag_name)
+                row.set_active(tag_name in self._selected_tags)
+                row.connect('notify::active', self._on_tag_toggled, tag_name)
+                # Colored swatch prefix
+                swatch = Gtk.Label(label='⬤')
+                swatch.set_valign(Gtk.Align.CENTER)
+                color = meta.get('color', '#aaaaaa')
+                swatch.set_markup(f'<span foreground="{color}">⬤</span>')
+                row.add_prefix(swatch)
+                if meta.get('warn_on_connect'):
+                    warn = Gtk.Label(label='⚠')
+                    warn.set_valign(Gtk.Align.CENTER)
+                    warn.set_tooltip_text('Warn on connect')
+                    warn.add_css_class('warning')
+                    row.add_suffix(warn)
+                tags_group.add(row)
+                self._tag_rows[tag_name] = row
+
         right_col = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
         right_col.set_hexpand(True)
         right_col.append(options_group)
+        right_col.append(tags_group)
         right_col.append(ssh_group)
 
         two_col = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)
@@ -265,6 +293,12 @@ class ConnectionDialog(Adw.Dialog):
         self._toast_overlay = Adw.ToastOverlay()
         self._toast_overlay.set_child(toolbar_view)
         self.set_child(self._toast_overlay)
+
+    def _on_tag_toggled(self, row, _param, tag_name):
+        if row.get_active():
+            self._selected_tags.add(tag_name)
+        else:
+            self._selected_tags.discard(tag_name)
 
     def _on_browse_key(self, _btn):
         dialog = Gtk.FileChooserNative(
@@ -451,6 +485,7 @@ class ConnectionDialog(Adw.Dialog):
             'ssh_user': self._ssh_user_row.get_text().strip(),
             'ssh_key_path': self._ssh_key_row.get_text().strip(),
             'ssh_passphrase': self._ssh_passphrase_row.get_text(),
+            'tags': sorted(self._selected_tags),
         }
         default_schema = self._default_schema_row.get_text().strip()
         if default_schema:

--- a/src/connection_dialog.py
+++ b/src/connection_dialog.py
@@ -208,16 +208,14 @@ class ConnectionDialog(Adw.Dialog):
 
         # ── Tags ─────────────────────────────────────────────────────────────
         tags_group = Adw.PreferencesGroup(title='Tags')
-        self._tag_rows = {}  # name → Adw.CheckRow
+        self._tag_checks = {}  # name → Gtk.CheckButton
         if self._store:
             registry = self._store.get_tags_registry()
             for tag_name in sorted(registry):
                 meta = registry[tag_name]
-                row = Adw.CheckRow(title=tag_name)
-                row.set_active(tag_name in self._selected_tags)
-                row.connect('notify::active', self._on_tag_toggled, tag_name)
+                row = Adw.ActionRow(title=tag_name)
                 # Colored swatch prefix
-                swatch = Gtk.Label(label='⬤')
+                swatch = Gtk.Label()
                 swatch.set_valign(Gtk.Align.CENTER)
                 color = meta.get('color', '#aaaaaa')
                 swatch.set_markup(f'<span foreground="{color}">⬤</span>')
@@ -228,8 +226,14 @@ class ConnectionDialog(Adw.Dialog):
                     warn.set_tooltip_text('Warn on connect')
                     warn.add_css_class('warning')
                     row.add_suffix(warn)
+                check = Gtk.CheckButton()
+                check.set_active(tag_name in self._selected_tags)
+                check.set_valign(Gtk.Align.CENTER)
+                check.connect('toggled', self._on_tag_toggled, tag_name)
+                row.add_suffix(check)
+                row.set_activatable_widget(check)
                 tags_group.add(row)
-                self._tag_rows[tag_name] = row
+                self._tag_checks[tag_name] = check
 
         right_col = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
         right_col.set_hexpand(True)
@@ -294,8 +298,8 @@ class ConnectionDialog(Adw.Dialog):
         self._toast_overlay.set_child(toolbar_view)
         self.set_child(self._toast_overlay)
 
-    def _on_tag_toggled(self, row, _param, tag_name):
-        if row.get_active():
+    def _on_tag_toggled(self, check, tag_name):
+        if check.get_active():
             self._selected_tags.add(tag_name)
         else:
             self._selected_tags.discard(tag_name)

--- a/src/connections.py
+++ b/src/connections.py
@@ -200,6 +200,14 @@ class ConnectionStore:
         self._save()
         return conn
 
+    def remove_tag_from_connections(self, tag_name):
+        """Remove a tag from all connections in a single save."""
+        for i, c in enumerate(self._connections):
+            if tag_name in c.get('tags', []):
+                updated = {**c, 'tags': [t for t in c['tags'] if t != tag_name]}
+                self._connections[i] = updated
+        self._save()
+
 
 class FavouritesStore:
     """Persists per-connection pinned table/view favourites."""

--- a/src/tags_dialog.py
+++ b/src/tags_dialog.py
@@ -152,8 +152,8 @@ class TagsDialog(Adw.Dialog):
                 updated = {**conn, 'tags': [t for t in conn['tags'] if t != name]}
                 try:
                     self._store.update(updated)
-                except Exception:
-                    pass
+                except Exception as e:
+                    print(f'Warning: failed to remove tag "{name}" from connection {conn.get("id")}: {e}')
         self._load_tags()
         self.emit('tags-changed')
 

--- a/src/tags_dialog.py
+++ b/src/tags_dialog.py
@@ -144,16 +144,9 @@ class TagsDialog(Adw.Dialog):
     def _on_delete_confirmed(self, _dialog, response, name):
         if response != 'delete':
             return
-        # Remove from registry
+        # Remove from registry and all connections (single save)
         self._store.remove_tag(name)
-        # Remove from all connections
-        for conn in self._store.list():
-            if name in conn.get('tags', []):
-                updated = {**conn, 'tags': [t for t in conn['tags'] if t != name]}
-                try:
-                    self._store.update(updated)
-                except Exception as e:
-                    print(f'Warning: failed to remove tag "{name}" from connection {conn.get("id")}: {e}')
+        self._store.remove_tag_from_connections(name)
         self._load_tags()
         self.emit('tags-changed')
 

--- a/src/tags_dialog.py
+++ b/src/tags_dialog.py
@@ -17,7 +17,7 @@ class TagsDialog(Adw.Dialog):
     }
 
     def __init__(self, store):
-        super().__init__(title='Manage Tags', content_width=480)
+        super().__init__(title='Manage Tags', content_width=480, content_height=560)
         self._store = store
         self._build_ui()
         self._load_tags()
@@ -67,9 +67,8 @@ class TagsDialog(Adw.Dialog):
         expander._tag_name = name
 
         # Colour swatch prefix
-        swatch = Gtk.Label(label='⬤')
+        swatch = Gtk.Label()
         swatch.set_valign(Gtk.Align.CENTER)
-        swatch.add_css_class('dim-label')
         self._apply_swatch_color(swatch, meta.get('color', _DEFAULT_COLOR))
         expander.add_prefix(swatch)
         expander._swatch = swatch
@@ -104,20 +103,10 @@ class TagsDialog(Adw.Dialog):
 
         return expander
 
-    def _apply_swatch_color(self, swatch, color):
-        # Remove old inline CSS and apply new one via a per-widget provider
-        if not hasattr(swatch, '_css_provider'):
-            provider = Gtk.CssProvider()
-            swatch._css_provider = provider
-            from gi.repository import Gdk
-            Gtk.StyleContext.add_provider_for_display(
-                Gdk.Display.get_default(), provider,
-                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
-            )
+    @staticmethod
+    def _apply_swatch_color(swatch, color):
         safe = color if _COLOR_RE.match(color or '') else _DEFAULT_COLOR
-        swatch._css_provider.load_from_string(
-            f'label {{ color: {safe}; }}'
-        )
+        swatch.set_markup(f'<span foreground="{safe}">⬤</span>')
 
     def _on_color_changed(self, row, _param, expander):
         color = row.get_text().strip()

--- a/src/tags_dialog.py
+++ b/src/tags_dialog.py
@@ -1,0 +1,203 @@
+import re
+
+import gi
+
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+
+from gi.repository import Gtk, Adw, GObject, GLib
+
+_COLOR_RE = re.compile(r'^#[0-9a-fA-F]{6}$')
+_DEFAULT_COLOR = '#aaaaaa'
+
+
+class TagsDialog(Adw.Dialog):
+    __gsignals__ = {
+        'tags-changed': (GObject.SignalFlags.RUN_FIRST, None, ()),
+    }
+
+    def __init__(self, store):
+        super().__init__(title='Manage Tags', content_width=480)
+        self._store = store
+        self._build_ui()
+        self._load_tags()
+
+    def _build_ui(self):
+        header = Adw.HeaderBar()
+
+        self._list_box = Gtk.ListBox()
+        self._list_box.add_css_class('boxed-list')
+        self._list_box.set_selection_mode(Gtk.SelectionMode.NONE)
+
+        add_row = Adw.ButtonRow(title='Add Tag')
+        add_row.set_start_icon_name('list-add-symbolic')
+        add_row.add_css_class('suggested-action')
+        add_row.connect('activated', self._on_add_tag)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
+        box.set_margin_top(16)
+        box.set_margin_bottom(20)
+        box.set_margin_start(20)
+        box.set_margin_end(20)
+        box.append(self._list_box)
+        box.append(add_row)
+
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_propagate_natural_height(True)
+        scroll.set_child(box)
+
+        toolbar_view = Adw.ToolbarView()
+        toolbar_view.add_top_bar(header)
+        toolbar_view.set_content(scroll)
+        self.set_child(toolbar_view)
+
+    def _load_tags(self):
+        while child := self._list_box.get_first_child():
+            self._list_box.remove(child)
+        registry = self._store.get_tags_registry()
+        for name in sorted(registry):
+            meta = registry[name]
+            self._list_box.append(self._build_tag_row(name, meta))
+
+    def _build_tag_row(self, name, meta):
+        expander = Adw.ExpanderRow(title=name)
+        expander._tag_name = name
+
+        # Colour swatch prefix
+        swatch = Gtk.Label(label='⬤')
+        swatch.set_valign(Gtk.Align.CENTER)
+        swatch.add_css_class('dim-label')
+        self._apply_swatch_color(swatch, meta.get('color', _DEFAULT_COLOR))
+        expander.add_prefix(swatch)
+        expander._swatch = swatch
+
+        # Color entry
+        color_row = Adw.EntryRow(title='Color (hex)')
+        color_row.set_text(meta.get('color', _DEFAULT_COLOR))
+        color_row.connect('notify::text', self._on_color_changed, expander)
+        expander.add_row(color_row)
+        expander._color_row = color_row
+
+        # Warn on connect switch
+        warn_row = Adw.SwitchRow(
+            title='Warn on connect',
+            subtitle='Show a confirmation prompt before connecting',
+        )
+        warn_row.set_active(meta.get('warn_on_connect', False))
+        warn_row.connect('notify::active', self._on_warn_changed, expander)
+        expander.add_row(warn_row)
+        expander._warn_row = warn_row
+
+        # Save / Delete buttons
+        save_row = Adw.ButtonRow(title='Save')
+        save_row.add_css_class('suggested-action')
+        save_row.connect('activated', self._on_save_tag, expander)
+        expander.add_row(save_row)
+
+        delete_row = Adw.ButtonRow(title='Delete Tag')
+        delete_row.add_css_class('destructive-action')
+        delete_row.connect('activated', self._on_delete_tag, expander)
+        expander.add_row(delete_row)
+
+        return expander
+
+    def _apply_swatch_color(self, swatch, color):
+        # Remove old inline CSS and apply new one via a per-widget provider
+        if not hasattr(swatch, '_css_provider'):
+            provider = Gtk.CssProvider()
+            swatch._css_provider = provider
+            from gi.repository import Gdk
+            Gtk.StyleContext.add_provider_for_display(
+                Gdk.Display.get_default(), provider,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+            )
+        safe = color if _COLOR_RE.match(color or '') else _DEFAULT_COLOR
+        swatch._css_provider.load_from_string(
+            f'label {{ color: {safe}; }}'
+        )
+
+    def _on_color_changed(self, row, _param, expander):
+        color = row.get_text().strip()
+        self._apply_swatch_color(expander._swatch, color)
+
+    def _on_warn_changed(self, _row, _param, _expander):
+        pass  # handled on Save
+
+    def _on_save_tag(self, _row, expander):
+        name = expander._tag_name
+        color = expander._color_row.get_text().strip()
+        if not _COLOR_RE.match(color):
+            expander._color_row.add_css_class('error')
+            return
+        expander._color_row.remove_css_class('error')
+        warn = expander._warn_row.get_active()
+        self._store.set_tag(name, color, warn)
+        expander.set_expanded(False)
+        self.emit('tags-changed')
+
+    def _on_delete_tag(self, _row, expander):
+        name = expander._tag_name
+        dialog = Adw.AlertDialog(
+            heading=f'Delete tag "{name}"?',
+            body='It will be removed from all connections.',
+        )
+        dialog.add_response('cancel', 'Cancel')
+        dialog.add_response('delete', 'Delete')
+        dialog.set_response_appearance('delete', Adw.ResponseAppearance.DESTRUCTIVE)
+        dialog.set_default_response('cancel')
+        dialog.set_close_response('cancel')
+        dialog.connect('response', self._on_delete_confirmed, name)
+        dialog.present(self)
+
+    def _on_delete_confirmed(self, _dialog, response, name):
+        if response != 'delete':
+            return
+        # Remove from registry
+        self._store.remove_tag(name)
+        # Remove from all connections
+        for conn in self._store.list():
+            if name in conn.get('tags', []):
+                updated = {**conn, 'tags': [t for t in conn['tags'] if t != name]}
+                try:
+                    self._store.update(updated)
+                except Exception:
+                    pass
+        self._load_tags()
+        self.emit('tags-changed')
+
+    def _on_add_tag(self, _row):
+        dialog = Adw.AlertDialog(heading='New Tag')
+        dialog.add_response('cancel', 'Cancel')
+        dialog.add_response('add', 'Add')
+        dialog.set_response_appearance('add', Adw.ResponseAppearance.SUGGESTED)
+        dialog.set_default_response('add')
+        dialog.set_close_response('cancel')
+
+        entry = Adw.EntryRow(title='Tag name')
+        color_entry = Adw.EntryRow(title='Color (hex)')
+        color_entry.set_text(_DEFAULT_COLOR)
+
+        box = Gtk.ListBox()
+        box.add_css_class('boxed-list')
+        box.set_selection_mode(Gtk.SelectionMode.NONE)
+        box.append(entry)
+        box.append(color_entry)
+        dialog.set_extra_child(box)
+
+        dialog.connect('response', self._on_add_confirmed, entry, color_entry)
+        dialog.present(self)
+
+    def _on_add_confirmed(self, _dialog, response, entry, color_entry):
+        if response != 'add':
+            return
+        name = entry.get_text().strip()
+        color = color_entry.get_text().strip()
+        if not name:
+            return
+        if not _COLOR_RE.match(color):
+            color = _DEFAULT_COLOR
+        if name not in self._store.get_tags_registry():
+            self._store.set_tag(name, color, False)
+        self._load_tags()
+        self.emit('tags-changed')

--- a/src/tags_dialog.py
+++ b/src/tags_dialog.py
@@ -29,10 +29,12 @@ class TagsDialog(Adw.Dialog):
         self._list_box.add_css_class('boxed-list')
         self._list_box.set_selection_mode(Gtk.SelectionMode.NONE)
 
-        add_row = Adw.ButtonRow(title='Add Tag')
-        add_row.set_start_icon_name('list-add-symbolic')
-        add_row.add_css_class('suggested-action')
-        add_row.connect('activated', self._on_add_tag)
+        add_btn = Gtk.Button(label='Add Tag')
+        add_btn.set_icon_name('list-add-symbolic')
+        add_btn.add_css_class('suggested-action')
+        add_btn.add_css_class('pill')
+        add_btn.set_halign(Gtk.Align.CENTER)
+        add_btn.connect('clicked', self._on_add_tag)
 
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
         box.set_margin_top(16)
@@ -40,7 +42,7 @@ class TagsDialog(Adw.Dialog):
         box.set_margin_start(20)
         box.set_margin_end(20)
         box.append(self._list_box)
-        box.append(add_row)
+        box.append(add_btn)
 
         scroll = Gtk.ScrolledWindow()
         scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)

--- a/src/window.py
+++ b/src/window.py
@@ -521,17 +521,18 @@ class TuskWindow(Adw.ApplicationWindow):
         self._mgr_search.connect('search-changed', self._on_mgr_search_changed)
         mgr_box.append(self._mgr_search)
 
-        # Tag filter chip strip (hidden until tags exist)
+        # Tag filter column (vertical, hidden until tags exist)
+        self._mgr_tag_strip = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        self._mgr_tag_strip.set_margin_top(MARGIN_XS)
+        self._mgr_tag_strip.set_margin_start(MARGIN_XS)
+        self._mgr_tag_strip.set_margin_end(MARGIN_XS)
+
         tag_scroll = Gtk.ScrolledWindow()
-        tag_scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.NEVER)
-        tag_scroll.set_margin_start(MARGIN_MD)
-        tag_scroll.set_margin_end(MARGIN_MD)
-        tag_scroll.set_margin_bottom(MARGIN_XS)
-        self._mgr_tag_strip = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        tag_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        tag_scroll.set_size_request(140, -1)
         tag_scroll.set_child(self._mgr_tag_strip)
         self._mgr_tag_scroll = tag_scroll
         tag_scroll.set_visible(False)
-        mgr_box.append(tag_scroll)
 
         # Connection list
         self._mgr_list = Gtk.ListBox()
@@ -543,8 +544,14 @@ class TuskWindow(Adw.ApplicationWindow):
 
         mgr_scroll = Gtk.ScrolledWindow()
         mgr_scroll.set_vexpand(True)
+        mgr_scroll.set_hexpand(True)
         mgr_scroll.set_child(self._mgr_list)
-        mgr_box.append(mgr_scroll)
+
+        content_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        content_box.set_vexpand(True)
+        content_box.append(tag_scroll)
+        content_box.append(mgr_scroll)
+        mgr_box.append(content_box)
 
         self._main_stack.add_named(mgr_box, 'manager')
 
@@ -1395,9 +1402,17 @@ class TuskWindow(Adw.ApplicationWindow):
             return
         self._mgr_tag_scroll.set_visible(True)
         for tag_name in sorted(tags):
-            btn = Gtk.ToggleButton(label=tag_name)
+            color = tags[tag_name].get('color', '#888888')
+            safe_color = color if _COLOR_RE.match(color) else '#888888'
+            lbl = Gtk.Label()
+            lbl.set_markup(
+                f'<span foreground="{safe_color}">⬤</span>'
+                f'  {GLib.markup_escape_text(tag_name)}'
+            )
+            lbl.set_xalign(0)
+            btn = Gtk.ToggleButton()
+            btn.set_child(lbl)
             btn.add_css_class('flat')
-            btn.add_css_class('pill')
             btn.set_active(tag_name in self._active_tag_filters)
             btn.connect('toggled', self._on_tag_filter_toggled, tag_name)
             self._mgr_tag_strip.append(btn)

--- a/src/window.py
+++ b/src/window.py
@@ -1112,16 +1112,16 @@ class TuskWindow(Adw.ApplicationWindow):
                 dialog.set_response_appearance('readonly', Adw.ResponseAppearance.SUGGESTED)
                 dialog.set_default_response('readonly')
                 dialog.set_close_response('cancel')
-                self._warned_conn_ids.add(conn_id)
-                dialog.connect('response', self._on_warn_response, conn, row)
+                dialog.connect('response', self._on_warn_response, conn, row, conn_id)
                 dialog.present(self)
                 return
 
         self._do_connect(conn, row)
 
-    def _on_warn_response(self, _dialog, response, conn, row):
+    def _on_warn_response(self, _dialog, response, conn, row, conn_id):
         if response == 'cancel':
             return
+        self._warned_conn_ids.add(conn_id)
         if response == 'readonly':
             conn = {**conn, 'read_only': True}
         self._do_connect(conn, row)
@@ -1336,6 +1336,7 @@ class TuskWindow(Adw.ApplicationWindow):
             self._mgr_list.remove(m_row)
             self._add_mgr_row(conn, position=pos, tags_registry=tags_registry)
         self._refresh_tag_strip()
+        self._set_active_conn(self._active_conn)
 
     def _show_connection_manager(self):
         self._main_stack.set_visible_child_name('manager')

--- a/src/window.py
+++ b/src/window.py
@@ -500,9 +500,11 @@ class TuskWindow(Adw.ApplicationWindow):
         tags_btn.connect('clicked', self._on_manage_tags)
         mgr_toolbar.append(tags_btn)
 
-        spacer = Gtk.Box()
-        spacer.set_hexpand(True)
-        mgr_toolbar.append(spacer)
+        self._mgr_search = Gtk.SearchEntry()
+        self._mgr_search.set_placeholder_text('Search…')
+        self._mgr_search.set_hexpand(True)
+        self._mgr_search.connect('search-changed', self._on_mgr_search_changed)
+        mgr_toolbar.append(self._mgr_search)
 
         mgr_add_btn = Gtk.Button(label='Add Connection')
         mgr_add_btn.add_css_class('suggested-action')
@@ -511,15 +513,6 @@ class TuskWindow(Adw.ApplicationWindow):
         mgr_toolbar.append(mgr_add_btn)
 
         mgr_box.append(mgr_toolbar)
-
-        # Search entry (Ctrl+F focuses it)
-        self._mgr_search = Gtk.SearchEntry()
-        self._mgr_search.set_placeholder_text('Search by name, host, database, or tag:…')
-        self._mgr_search.set_margin_start(MARGIN_MD)
-        self._mgr_search.set_margin_end(MARGIN_MD)
-        self._mgr_search.set_margin_bottom(MARGIN_XS)
-        self._mgr_search.connect('search-changed', self._on_mgr_search_changed)
-        mgr_box.append(self._mgr_search)
 
         # Tag filter column (vertical, hidden until tags exist)
         self._mgr_tag_strip = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)

--- a/src/window.py
+++ b/src/window.py
@@ -41,6 +41,7 @@ class TuskWindow(Adw.ApplicationWindow):
         self._conn_search = ''
         self._conn_sort = prefs.get('conn_sort', 'manual')
         self._active_tag_filters = set()
+        self._warned_conn_ids = set()  # conn_ids warned this session (warn_on_connect)
         self._conn_mgr_rows = {}       # conn_id → manager list row
         self._conn_popover_rows = {}   # conn_id → popover list row
         self._sidebar_css = Gtk.CssProvider()
@@ -494,6 +495,11 @@ class TuskWindow(Adw.ApplicationWindow):
         self._sort_btn.add_css_class('flat')
         mgr_toolbar.append(self._sort_btn)
 
+        tags_btn = Gtk.Button(label='Manage Tags')
+        tags_btn.add_css_class('flat')
+        tags_btn.connect('clicked', self._on_manage_tags)
+        mgr_toolbar.append(tags_btn)
+
         spacer = Gtk.Box()
         spacer.set_hexpand(True)
         mgr_toolbar.append(spacer)
@@ -760,7 +766,7 @@ class TuskWindow(Adw.ApplicationWindow):
 
     def _on_add_connection(self, _btn):
         self._conn_popover.popdown()
-        dlg = ConnectionDialog(parent=self)
+        dlg = ConnectionDialog(parent=self, store=self._store)
         dlg.connect('connection-saved', self._on_connection_added)
         dlg.present(self)
 
@@ -977,7 +983,7 @@ class TuskWindow(Adw.ApplicationWindow):
 
     def _on_edit_connection(self, row):
         self._conn_popover.popdown()
-        dlg = ConnectionDialog(parent=self, connection=row._conn)
+        dlg = ConnectionDialog(parent=self, connection=row._conn, store=self._store)
         dlg.connect('connection-saved', self._on_connection_updated, row)
         dlg.present(self)
 
@@ -988,7 +994,7 @@ class TuskWindow(Adw.ApplicationWindow):
         except KeyringUnavailableError as e:
             self._show_keyring_error(str(e))
             return
-        dlg = ConnectionDialog(parent=self, connection=conn, duplicate=True)
+        dlg = ConnectionDialog(parent=self, connection=conn, duplicate=True, store=self._store)
         dlg.connect('connection-saved', self._on_connection_duplicated, row)
         dlg.present(self)
 
@@ -1086,6 +1092,41 @@ class TuskWindow(Adw.ApplicationWindow):
             self._show_keyring_error(str(e))
             return
 
+        # warn_on_connect: once per session per connection
+        conn_id = row._conn['id']
+        if conn_id not in self._warned_conn_ids:
+            registry = self._store.get_tags_registry()
+            warn_tags = [
+                t for t in conn.get('tags', [])
+                if registry.get(t, {}).get('warn_on_connect')
+            ]
+            if warn_tags:
+                tag_list = ', '.join(f'"{t}"' for t in warn_tags)
+                dialog = Adw.AlertDialog(
+                    heading='Production environment',
+                    body=f'This connection is tagged {tag_list}. Proceed with care.',
+                )
+                dialog.add_response('cancel', 'Cancel')
+                dialog.add_response('readonly', 'Connect as Read-Only')
+                dialog.add_response('connect', 'Connect')
+                dialog.set_response_appearance('readonly', Adw.ResponseAppearance.SUGGESTED)
+                dialog.set_default_response('readonly')
+                dialog.set_close_response('cancel')
+                self._warned_conn_ids.add(conn_id)
+                dialog.connect('response', self._on_warn_response, conn, row)
+                dialog.present(self)
+                return
+
+        self._do_connect(conn, row)
+
+    def _on_warn_response(self, _dialog, response, conn, row):
+        if response == 'cancel':
+            return
+        if response == 'readonly':
+            conn = {**conn, 'read_only': True}
+        self._do_connect(conn, row)
+
+    def _do_connect(self, conn, row):
         # Record last connected timestamp on both row copies
         now_ts = datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z')
         conn_id = row._conn['id']
@@ -1278,6 +1319,23 @@ class TuskWindow(Adw.ApplicationWindow):
                 widget.set_connection(conn)
 
     # ── Connection manager helpers ────────────────────────────────────────────
+
+    def _on_manage_tags(self, _btn):
+        from tags_dialog import TagsDialog
+        dlg = TagsDialog(self._store)
+        dlg.connect('tags-changed', self._on_tags_changed)
+        dlg.present(self)
+
+    def _on_tags_changed(self, _dlg):
+        # Rebuild every manager row so tag chips and colors are current
+        tags_registry = self._store.get_tags_registry()
+        for conn_id, m_row in list(self._conn_mgr_rows.items()):
+            conn = m_row._conn
+            pos = m_row.get_index()
+            self._conn_mgr_rows.pop(conn_id)
+            self._mgr_list.remove(m_row)
+            self._add_mgr_row(conn, position=pos, tags_registry=tags_registry)
+        self._refresh_tag_strip()
 
     def _show_connection_manager(self):
         self._main_stack.set_visible_child_name('manager')

--- a/src/window.py
+++ b/src/window.py
@@ -1327,10 +1327,17 @@ class TuskWindow(Adw.ApplicationWindow):
         dlg.present(self)
 
     def _on_tags_changed(self, _dlg):
-        # Rebuild every manager row so tag chips and colors are current
+        # Rebuild every manager row using fresh store data so tag changes
+        # (including deletions) aren't overwritten when _do_connect() later
+        # calls store.update(row._conn).
         tags_registry = self._store.get_tags_registry()
+        fresh = {c['id']: c for c in self._store.list()}
+        # Refresh popover row _conn references (no visual rebuild needed)
+        for conn_id, p_row in self._conn_popover_rows.items():
+            if conn_id in fresh:
+                p_row._conn = fresh[conn_id]
         for conn_id, m_row in list(self._conn_mgr_rows.items()):
-            conn = m_row._conn
+            conn = fresh.get(conn_id, m_row._conn)
             pos = m_row.get_index()
             self._conn_mgr_rows.pop(conn_id)
             self._mgr_list.remove(m_row)


### PR DESCRIPTION
## Summary
- New "Manage Tags" dialog: create tags with hex color and warn-on-connect toggle; edit or delete existing tags (deletion cascades to all connections)
- Tag assignment in the Add/Edit Connection dialog via checkboxes with colored swatches
- Warn-on-connect prompt (once per session) when connecting to a connection tagged with a warn-on-connect tag; supports Cancel, Connect, and Connect as Read-Only responses
- Vertical tag filter column in the connection manager; filter chips with colored dots

## Issues
Closes #286

## Test plan
- Create a tag with a color and warn-on-connect enabled
- Assign that tag to a connection via Edit Connection
- Connect to the connection — confirm the warning dialog appears
- Cancel → connecting again should warn again; Connect → subsequent connects skip the dialog
- Connect as Read-Only → connection opens read-only
- Delete the tag — verify it disappears from all connection records
- Tag filter column: toggle a tag chip and verify only matching connections show
- Open connection manager with no tags — confirm no Tags section appears in Add/Edit Connection, and no filter column is shown