### PR TITLE
feat: connection health, stale cleanup, JSON/pgpass export & import

### DIFF
--- a/src/connections.py
+++ b/src/connections.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import uuid
@@ -207,6 +208,69 @@ class ConnectionStore:
                 updated = {**c, 'tags': [t for t in c['tags'] if t != tag_name]}
                 self._connections[i] = updated
         self._save()
+
+    def export_json(self, include_passwords=False):
+        """Return a JSON-serialisable dict of all connections and the tags registry."""
+        conns = []
+        for c in self._connections:
+            entry = dict(c)
+            if include_passwords:
+                try:
+                    pwd = keyring.get_password(KEYRING_SERVICE, c['id']) or ''
+                    if pwd:
+                        entry['password'] = pwd
+                except Exception:
+                    pass
+                try:
+                    ssh_pp = keyring.get_password(KEYRING_SERVICE, _ssh_key(c['id'])) or ''
+                    if ssh_pp:
+                        entry['ssh_passphrase'] = ssh_pp
+                except Exception:
+                    pass
+            conns.append(entry)
+        return {
+            'schema_version': SCHEMA_VERSION,
+            'exported_at': datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z'),
+            'tags_registry': dict(self._tags_registry),
+            'connections': conns,
+        }
+
+    def bulk_import(self, conns, tags_registry=None):
+        """Import a list of connection dicts, skipping any whose id already exists.
+
+        Name collisions are resolved by appending ' (imported)' to the incoming name.
+        Returns (added, skipped) counts.
+        """
+        if tags_registry:
+            for name, meta in tags_registry.items():
+                self._tags_registry.setdefault(name, meta)
+        existing_ids = {c['id'] for c in self._connections}
+        existing_names = {c['name'] for c in self._connections}
+        added = 0
+        skipped = 0
+        for conn in conns:
+            if conn.get('id') in existing_ids:
+                skipped += 1
+                continue
+            conn = dict(conn)
+            conn['id'] = conn.get('id') or str(uuid.uuid4())
+            if conn.get('name', '') in existing_names:
+                conn['name'] = conn['name'] + ' (imported)'
+            pwd = conn.pop('password', '')
+            ssh_pp = conn.pop('ssh_passphrase', '')
+            _apply_defaults(conn, self._tags_registry)
+            try:
+                keyring.set_password(KEYRING_SERVICE, conn['id'], pwd)
+                keyring.set_password(KEYRING_SERVICE, _ssh_key(conn['id']), ssh_pp)
+            except Exception:
+                pass
+            self._connections.append(conn)
+            existing_ids.add(conn['id'])
+            existing_names.add(conn['name'])
+            added += 1
+        if added > 0 or tags_registry:
+            self._save()
+        return added, skipped
 
 
 class FavouritesStore:

--- a/src/connections.py
+++ b/src/connections.py
@@ -210,7 +210,11 @@ class ConnectionStore:
         self._save()
 
     def export_json(self, include_passwords=False):
-        """Return a JSON-serialisable dict of all connections and the tags registry."""
+        """Return a JSON-serialisable dict of all connections and the tags registry.
+
+        Raises KeyringUnavailableError if include_passwords=True and any keyring
+        lookup fails, so callers can surface the error to the user.
+        """
         conns = []
         for c in self._connections:
             entry = dict(c)
@@ -219,14 +223,14 @@ class ConnectionStore:
                     pwd = keyring.get_password(KEYRING_SERVICE, c['id']) or ''
                     if pwd:
                         entry['password'] = pwd
-                except Exception:
-                    pass
+                except Exception as e:
+                    raise KeyringUnavailableError(str(e)) from e
                 try:
                     ssh_pp = keyring.get_password(KEYRING_SERVICE, _ssh_key(c['id'])) or ''
                     if ssh_pp:
                         entry['ssh_passphrase'] = ssh_pp
-                except Exception:
-                    pass
+                except Exception as e:
+                    raise KeyringUnavailableError(str(e)) from e
             conns.append(entry)
         return {
             'schema_version': SCHEMA_VERSION,
@@ -248,7 +252,11 @@ class ConnectionStore:
         existing_names = {c['name'] for c in self._connections}
         added = 0
         skipped = 0
+        required = ('name', 'host', 'port', 'database', 'username')
         for conn in conns:
+            if any(not conn.get(f) for f in required):
+                skipped += 1
+                continue
             if conn.get('id') in existing_ids:
                 skipped += 1
                 continue

--- a/src/connections_import_dialog.py
+++ b/src/connections_import_dialog.py
@@ -1,0 +1,94 @@
+import gi
+
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+
+from gi.repository import Gtk, Adw, GObject
+
+
+class ConnectionsImportDialog(Adw.Dialog):
+    """Preview dialog for JSON connection import.
+
+    Emits 'import-confirmed' with (conns_to_import, tags_registry) after the
+    user clicks Import Selected.
+    """
+
+    __gsignals__ = {
+        'import-confirmed': (GObject.SignalFlags.RUN_FIRST, None,
+                             (GObject.TYPE_PYOBJECT, GObject.TYPE_PYOBJECT)),
+    }
+
+    def __init__(self, incoming_conns, incoming_tags, existing_names):
+        super().__init__(title='Import Connections', content_width=520, content_height=560)
+        self._incoming_tags = incoming_tags
+        self._checks = {}   # conn_id → (Gtk.CheckButton, resolved_conn)
+        self._build_ui(incoming_conns, existing_names)
+
+    def _build_ui(self, incoming_conns, existing_names):
+        header = Adw.HeaderBar()
+
+        list_box = Gtk.ListBox()
+        list_box.add_css_class('boxed-list')
+        list_box.set_selection_mode(Gtk.SelectionMode.NONE)
+
+        conflict_count = 0
+        for conn in incoming_conns:
+            resolved = dict(conn)
+            clash = conn.get('name', '') in existing_names
+            if clash:
+                resolved['name'] = conn['name'] + ' (imported)'
+                conflict_count += 1
+            row = Adw.ActionRow(title=resolved['name'])
+            subtitle = f'{conn.get("host", "")}:{conn.get("port", 5432)}/{conn.get("database", "")}'
+            if clash:
+                subtitle += ' — renamed from "' + conn['name'] + '"'
+            row.set_subtitle(subtitle)
+            check = Gtk.CheckButton()
+            check.set_active(True)
+            check.set_valign(Gtk.Align.CENTER)
+            row.add_suffix(check)
+            row.set_activatable_widget(check)
+            list_box.append(row)
+            self._checks[conn.get('id', '')] = (check, resolved)
+
+        n = len(incoming_conns)
+        summary_parts = [f'{n} connection{"s" if n != 1 else ""} found.']
+        if conflict_count:
+            summary_parts.append(
+                f'{conflict_count} name{"s" if conflict_count != 1 else ""} '
+                'already exist and will be imported with "(imported)" suffix.'
+            )
+        summary = Gtk.Label(label=' '.join(summary_parts))
+        summary.add_css_class('dim-label')
+        summary.set_wrap(True)
+        summary.set_xalign(0)
+
+        import_btn = Gtk.Button(label='Import Selected')
+        import_btn.add_css_class('suggested-action')
+        import_btn.add_css_class('pill')
+        import_btn.set_halign(Gtk.Align.CENTER)
+        import_btn.connect('clicked', self._on_import)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_margin_top(16)
+        box.set_margin_bottom(20)
+        box.set_margin_start(20)
+        box.set_margin_end(20)
+        box.append(summary)
+        box.append(list_box)
+        box.append(import_btn)
+
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_propagate_natural_height(True)
+        scroll.set_child(box)
+
+        toolbar_view = Adw.ToolbarView()
+        toolbar_view.add_top_bar(header)
+        toolbar_view.set_content(scroll)
+        self.set_child(toolbar_view)
+
+    def _on_import(self, _btn):
+        selected = [resolved for (check, resolved) in self._checks.values() if check.get_active()]
+        self.emit('import-confirmed', selected, self._incoming_tags)
+        self.close()

--- a/src/connections_import_dialog.py
+++ b/src/connections_import_dialog.py
@@ -32,7 +32,7 @@ class ConnectionsImportDialog(Adw.Dialog):
         list_box.set_selection_mode(Gtk.SelectionMode.NONE)
 
         conflict_count = 0
-        for conn in incoming_conns:
+        for idx, conn in enumerate(incoming_conns):
             resolved = dict(conn)
             clash = conn.get('name', '') in existing_names
             if clash:
@@ -49,7 +49,7 @@ class ConnectionsImportDialog(Adw.Dialog):
             row.add_suffix(check)
             row.set_activatable_widget(check)
             list_box.append(row)
-            self._checks[conn.get('id', '')] = (check, resolved)
+            self._checks[idx] = (check, resolved)
 
         n = len(incoming_conns)
         summary_parts = [f'{n} connection{"s" if n != 1 else ""} found.']

--- a/src/prefs_dialog.py
+++ b/src/prefs_dialog.py
@@ -41,6 +41,15 @@ class PrefsDialog(Adw.PreferencesDialog):
         editor_page.add(notif_group)
         notif_group.add(self._notify_threshold_row())
 
+        conn_page = Adw.PreferencesPage(
+            title='Connections',
+            icon_name='network-server-symbolic',
+        )
+        self.add(conn_page)
+        stale_group = Adw.PreferencesGroup(title='Stale Connection Cleanup')
+        conn_page.add(stale_group)
+        stale_group.add(self._stale_days_row())
+
     def _font_combo_row(self, key):
         model = Gtk.StringList()
         for label in FONT_LABELS:
@@ -68,6 +77,17 @@ class PrefsDialog(Adw.PreferencesDialog):
             adjustment=adj,
         )
         row.connect('notify::value', lambda r, _: prefs.put('notify_threshold_s', int(r.get_value())))
+        return row
+
+    def _stale_days_row(self):
+        current = prefs.get('stale_days', 30)
+        adj = Gtk.Adjustment(value=current, lower=1, upper=365, step_increment=1, page_increment=7)
+        row = Adw.SpinRow(
+            title='Stale threshold',
+            subtitle='Connections unused for this many days are shown in cleanup',
+            adjustment=adj,
+        )
+        row.connect('notify::value', lambda r, _: prefs.put('stale_days', int(r.get_value())))
         return row
 
     def _save(self, key, value):

--- a/src/stale_dialog.py
+++ b/src/stale_dialog.py
@@ -1,0 +1,150 @@
+import datetime
+
+import gi
+
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+
+from gi.repository import Gtk, Adw, GObject
+
+import prefs
+
+
+def _is_stale(conn, threshold_days):
+    ts = conn.get('last_connected')
+    if not ts:
+        return True
+    try:
+        dt = datetime.datetime.fromisoformat(ts.rstrip('Z')).replace(tzinfo=datetime.timezone.utc)
+        age = (datetime.datetime.now(datetime.timezone.utc) - dt).days
+        return age >= threshold_days
+    except (ValueError, TypeError):
+        return True
+
+
+class StaleConnectionsDialog(Adw.Dialog):
+    __gsignals__ = {
+        'connections-deleted': (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+    }
+
+    def __init__(self, store, conn_health=None):
+        super().__init__(title='Clean Up Stale Connections', content_width=520, content_height=560)
+        self._store = store
+        self._conn_health = conn_health or {}
+        self._checks = {}  # conn_id → Gtk.CheckButton
+        self._threshold = prefs.get('stale_days', 30)
+        self._build_ui()
+
+    def _build_ui(self):
+        header = Adw.HeaderBar()
+
+        self._list_box = Gtk.ListBox()
+        self._list_box.add_css_class('boxed-list')
+        self._list_box.set_selection_mode(Gtk.SelectionMode.NONE)
+
+        stale = [c for c in self._store.list() if _is_stale(c, self._threshold)]
+
+        if not stale:
+            empty = Adw.StatusPage(
+                title='No Stale Connections',
+                description=f'All connections have been used within the last {self._threshold} days.',
+                icon_name='emblem-ok-symbolic',
+            )
+            toolbar_view = Adw.ToolbarView()
+            toolbar_view.add_top_bar(header)
+            toolbar_view.set_content(empty)
+            self.set_child(toolbar_view)
+            return
+
+        for conn in stale:
+            self._list_box.append(self._build_row(conn))
+
+        delete_btn = Gtk.Button(label='Delete Selected')
+        delete_btn.add_css_class('destructive-action')
+        delete_btn.add_css_class('pill')
+        delete_btn.set_halign(Gtk.Align.CENTER)
+        delete_btn.connect('clicked', self._on_delete_clicked)
+
+        summary = Gtk.Label(
+            label=f'{len(stale)} connection{"s" if len(stale) != 1 else ""} '
+                  f'unused for {self._threshold}+ days or never connected'
+        )
+        summary.add_css_class('dim-label')
+        summary.set_wrap(True)
+        summary.set_xalign(0)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_margin_top(16)
+        box.set_margin_bottom(20)
+        box.set_margin_start(20)
+        box.set_margin_end(20)
+        box.append(summary)
+        box.append(self._list_box)
+        box.append(delete_btn)
+
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_propagate_natural_height(True)
+        scroll.set_child(box)
+
+        toolbar_view = Adw.ToolbarView()
+        toolbar_view.add_top_bar(header)
+        toolbar_view.set_content(scroll)
+        self.set_child(toolbar_view)
+
+    def _build_row(self, conn):
+        row = Adw.ActionRow(title=conn['name'])
+        row.set_subtitle(self._last_connected_label(conn))
+
+        # Health dot
+        health = self._conn_health.get(conn['id'], {})
+        status = health.get('status', 'unknown')
+        color = {'ok': '#33d17a', 'error': '#e01b24', 'tunnel': '#e5a50a'}.get(status, '#888888')
+        dot = Gtk.Label()
+        dot.set_markup(f'<span foreground="{color}">⬤</span>')
+        dot.set_valign(Gtk.Align.CENTER)
+        row.add_prefix(dot)
+
+        check = Gtk.CheckButton()
+        check.set_active(True)
+        check.set_valign(Gtk.Align.CENTER)
+        row.add_suffix(check)
+        row.set_activatable_widget(check)
+        self._checks[conn['id']] = check
+        return row
+
+    @staticmethod
+    def _last_connected_label(conn):
+        ts = conn.get('last_connected')
+        if not ts:
+            return 'Never connected'
+        try:
+            dt = datetime.datetime.fromisoformat(ts.rstrip('Z')).replace(tzinfo=datetime.timezone.utc)
+            delta = datetime.datetime.now(datetime.timezone.utc) - dt
+            days = delta.days
+            return f'Last connected {days} day{"s" if days != 1 else ""} ago'
+        except (ValueError, TypeError):
+            return 'Never connected'
+
+    def _on_delete_clicked(self, _btn):
+        selected_ids = [cid for cid, cb in self._checks.items() if cb.get_active()]
+        if not selected_ids:
+            return
+        n = len(selected_ids)
+        dialog = Adw.AlertDialog(
+            heading=f'Delete {n} connection{"s" if n != 1 else ""}?',
+            body='This cannot be undone.',
+        )
+        dialog.add_response('cancel', 'Cancel')
+        dialog.add_response('delete', f'Delete {n}')
+        dialog.set_response_appearance('delete', Adw.ResponseAppearance.DESTRUCTIVE)
+        dialog.set_default_response('cancel')
+        dialog.set_close_response('cancel')
+        dialog.connect('response', self._on_confirmed, selected_ids)
+        dialog.present(self)
+
+    def _on_confirmed(self, _dialog, response, selected_ids):
+        if response != 'delete':
+            return
+        self.emit('connections-deleted', selected_ids)
+        self.close()

--- a/src/window.py
+++ b/src/window.py
@@ -1483,14 +1483,12 @@ class TuskWindow(Adw.ApplicationWindow):
         def _run():
             ts = datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z')
             try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                sock.settimeout(3)
-                sock.connect((conn['host'], int(conn['port'])))
-                sock.close()
+                with socket.create_connection((conn['host'], int(conn['port'])), timeout=3):
+                    pass
                 result = {'status': 'ok', 'msg': 'Reachable', 'ts': ts}
             except socket.timeout:
                 result = {'status': 'error', 'msg': 'Timed out', 'ts': ts}
-            except OSError as exc:
+            except (OSError, ValueError) as exc:
                 result = {'status': 'error', 'msg': str(exc), 'ts': ts}
             self._conn_health[conn_id] = result
             GLib.idle_add(self._update_health_dot, conn_id)
@@ -1541,13 +1539,12 @@ class TuskWindow(Adw.ApplicationWindow):
             if not password:
                 skipped_no_pwd += 1
                 continue
-            line = ':'.join([
-                _escape(conn['host']),
-                _escape(conn['port']),
-                '*',
-                _escape(conn['username']),
-                _escape(password),
-            ])
+            fields = [str(conn.get('host', '')), str(conn.get('port', '')),
+                      '*', str(conn.get('username', '')), password]
+            if any('\n' in v or '\r' in v for v in fields):
+                skipped_no_pwd += 1
+                continue
+            line = ':'.join(_escape(v) for v in fields)
             if line in new_lines:
                 skipped_dup += 1
                 continue
@@ -1598,7 +1595,11 @@ class TuskWindow(Adw.ApplicationWindow):
 
     def _on_export_connections_json(self):
         def _do_export(include_passwords):
-            data = self._store.export_json(include_passwords=include_passwords)
+            try:
+                data = self._store.export_json(include_passwords=include_passwords)
+            except KeyringUnavailableError as e:
+                self._show_toast(f'Export failed: keyring unavailable — {e}')
+                return
             file_dialog = Gtk.FileDialog()
             file_dialog.set_title('Export Connections')
             file_dialog.set_initial_name('connections.tusk-connections.json')
@@ -1631,6 +1632,9 @@ class TuskWindow(Adw.ApplicationWindow):
         import json as _json
         try:
             path = gfile.get_path()
+            if path is None:
+                self._show_toast('Export failed: only local files are supported.')
+                return
             tmp = path + '.tmp'
             with open(tmp, 'w', encoding='utf-8') as f:
                 _json.dump(data, f, indent=2)
@@ -1663,6 +1667,9 @@ class TuskWindow(Adw.ApplicationWindow):
             return
         try:
             path = gfile.get_path()
+            if path is None:
+                self._show_toast('Import failed: only local files are supported.')
+                return
             with open(path, encoding='utf-8') as f:
                 data = _json.load(f)
         except (OSError, ValueError) as e:

--- a/src/window.py
+++ b/src/window.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import re
+import socket
 import threading
 
 import gi
@@ -1472,8 +1473,6 @@ class TuskWindow(Adw.ApplicationWindow):
         dot.set_tooltip_text(tip)
 
     def _check_health(self, conn):
-        import socket
-        import threading as _threading
         conn_id = conn['id']
         # Tunnel/proxy connections can't be TCP-checked to the raw host
         if conn.get('ssh_host') or conn.get('cloud_proxy_enabled'):
@@ -1486,12 +1485,9 @@ class TuskWindow(Adw.ApplicationWindow):
             try:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock.settimeout(3)
-                err = sock.connect_ex((conn['host'], int(conn['port'])))
+                sock.connect((conn['host'], int(conn['port'])))
                 sock.close()
-                if err == 0:
-                    result = {'status': 'ok', 'msg': 'Reachable', 'ts': ts}
-                else:
-                    result = {'status': 'error', 'msg': os.strerror(err), 'ts': ts}
+                result = {'status': 'ok', 'msg': 'Reachable', 'ts': ts}
             except socket.timeout:
                 result = {'status': 'error', 'msg': 'Timed out', 'ts': ts}
             except OSError as exc:
@@ -1499,7 +1495,7 @@ class TuskWindow(Adw.ApplicationWindow):
             self._conn_health[conn_id] = result
             GLib.idle_add(self._update_health_dot, conn_id)
 
-        _threading.Thread(target=_run, daemon=True).start()
+        threading.Thread(target=_run, daemon=True).start()
 
     def _update_health_dot(self, conn_id):
         row = self._conn_mgr_rows.get(conn_id)
@@ -1704,11 +1700,13 @@ class TuskWindow(Adw.ApplicationWindow):
         dlg.present(self)
 
     def _on_stale_connections_deleted(self, _dlg, conn_ids):
+        deleted = 0
         for conn_id in conn_ids:
             try:
                 self._store.remove(conn_id)
-            except Exception:
-                pass
+            except Exception as e:
+                self._show_toast(f'Could not delete connection: {e}')
+                continue
             mgr_row = self._conn_mgr_rows.pop(conn_id, None)
             if mgr_row:
                 self._mgr_list.remove(mgr_row)
@@ -1718,8 +1716,9 @@ class TuskWindow(Adw.ApplicationWindow):
             self._conn_health.pop(conn_id, None)
             if conn_id == self._active_conn_id:
                 self._set_active_conn(None)
-        n = len(conn_ids)
-        self._show_toast(f'{n} connection{"s" if n != 1 else ""} deleted.')
+            deleted += 1
+        if deleted:
+            self._show_toast(f'{deleted} connection{"s" if deleted != 1 else ""} deleted.')
 
     def _show_toast(self, msg, timeout=4):
         toast = Adw.Toast(title=msg)

--- a/src/window.py
+++ b/src/window.py
@@ -42,6 +42,7 @@ class TuskWindow(Adw.ApplicationWindow):
         self._conn_sort = prefs.get('conn_sort', 'manual')
         self._active_tag_filters = set()
         self._warned_conn_ids = set()  # conn_ids warned this session (warn_on_connect)
+        self._conn_health = {}         # conn_id → {status, msg, ts}
         self._conn_mgr_rows = {}       # conn_id → manager list row
         self._conn_popover_rows = {}   # conn_id → popover list row
         self._sidebar_css = Gtk.CssProvider()
@@ -93,8 +94,13 @@ class TuskWindow(Adw.ApplicationWindow):
         add('close-tab',      lambda *_: self._close_current_tab())
         add('next-tab',       lambda *_: self._tab_view.select_next_page())
         add('prev-tab',       lambda *_: self._tab_view.select_previous_page())
-        add('import-pgpass',  lambda *_: self._on_import_pgpass())
-        add('show-connection-manager', lambda *_: self._show_connection_manager())
+        add('import-pgpass',              lambda *_: self._on_import_pgpass())
+        add('show-connection-manager',    lambda *_: self._show_connection_manager())
+        add('check-all-health',           lambda *_: self._on_check_all_health())
+        add('export-pgpass-bulk',         lambda *_: self._on_export_pgpass_bulk())
+        add('export-connections-json',    lambda *_: self._on_export_connections_json())
+        add('import-connections-json',    lambda *_: self._on_import_connections_json())
+        add('cleanup-stale',              lambda *_: self._on_cleanup_stale())
         for _key in ('name', 'last-connected', 'manual'):
             _a = Gio.SimpleAction.new(f'conn-sort-{_key}', None)
             _a.connect('activate', lambda _act, _par, k=_key: self._on_sort_changed(k))
@@ -506,6 +512,19 @@ class TuskWindow(Adw.ApplicationWindow):
         self._mgr_search.connect('search-changed', self._on_mgr_search_changed)
         mgr_toolbar.append(self._mgr_search)
 
+        overflow_menu = Gio.Menu()
+        overflow_menu.append('Check all connections', 'win.check-all-health')
+        overflow_menu.append('Export all to .pgpass…', 'win.export-pgpass-bulk')
+        overflow_menu.append('Export connections…', 'win.export-connections-json')
+        overflow_menu.append('Import connections…', 'win.import-connections-json')
+        overflow_menu.append('Clean up stale…', 'win.cleanup-stale')
+        overflow_btn = Gtk.MenuButton()
+        overflow_btn.set_icon_name('view-more-symbolic')
+        overflow_btn.set_tooltip_text('More actions')
+        overflow_btn.set_menu_model(overflow_menu)
+        overflow_btn.add_css_class('flat')
+        mgr_toolbar.append(overflow_btn)
+
         mgr_add_btn = Gtk.Button(label='Add Connection')
         mgr_add_btn.add_css_class('suggested-action')
         mgr_add_btn.add_css_class('pill')
@@ -723,9 +742,17 @@ class TuskWindow(Adw.ApplicationWindow):
         row.add_prefix(icon)
         row._active_icon = icon
 
+        # Health dot — grey until a check has run
+        health_dot = Gtk.Label()
+        health_dot.set_valign(Gtk.Align.CENTER)
+        self._apply_health_dot(health_dot, self._conn_health.get(conn['id'], {}))
+        row.add_prefix(health_dot)
+        row._health_dot = health_dot
+
         # Context menu
         menu = Gio.Menu()
         menu.append('Disconnect', 'mgr.disconnect')
+        menu.append('Check connection', 'mgr.check-health')
         menu.append('Edit', 'mgr.edit')
         menu.append('Duplicate', 'mgr.duplicate')
         menu.append('Copy as URI', 'mgr.copy-uri')
@@ -746,6 +773,7 @@ class TuskWindow(Adw.ApplicationWindow):
         ag.add_action(disconnect_action)
         row._disconnect_action = disconnect_action
         for name, cb in [
+            ('check-health',  lambda _a, _p, r=row: self._check_health(r._conn)),
             ('edit',          lambda _a, _p, r=row: self._on_edit_connection(r)),
             ('duplicate',     lambda _a, _p, r=row: self._on_duplicate_connection(r)),
             ('copy-uri',      lambda _a, _p, r=row: self._on_copy_as_uri(r)),
@@ -1424,6 +1452,279 @@ class TuskWindow(Adw.ApplicationWindow):
         else:
             self._active_tag_filters.discard(tag_name)
         self._mgr_list.invalidate_filter()
+
+    # ── Health checks ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _apply_health_dot(dot, health):
+        status = health.get('status', 'unknown')
+        color = {'ok': '#33d17a', 'error': '#e01b24', 'tunnel': '#e5a50a'}.get(status, '#888888')
+        dot.set_markup(f'<span foreground="{color}">⬤</span>')
+        msg = health.get('msg', 'Not checked')
+        ts = health.get('ts')
+        tip = msg
+        if ts:
+            try:
+                dt = datetime.datetime.fromisoformat(ts.rstrip('Z')).replace(tzinfo=datetime.timezone.utc)
+                tip += f'\nChecked {dt.strftime("%H:%M:%S UTC")}'
+            except (ValueError, TypeError):
+                pass
+        dot.set_tooltip_text(tip)
+
+    def _check_health(self, conn):
+        import socket
+        import threading as _threading
+        conn_id = conn['id']
+        # Tunnel/proxy connections can't be TCP-checked to the raw host
+        if conn.get('ssh_host') or conn.get('cloud_proxy_enabled'):
+            self._conn_health[conn_id] = {'status': 'tunnel', 'msg': 'Requires tunnel/proxy', 'ts': None}
+            self._update_health_dot(conn_id)
+            return
+
+        def _run():
+            ts = datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z')
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(3)
+                err = sock.connect_ex((conn['host'], int(conn['port'])))
+                sock.close()
+                if err == 0:
+                    result = {'status': 'ok', 'msg': 'Reachable', 'ts': ts}
+                else:
+                    result = {'status': 'error', 'msg': os.strerror(err), 'ts': ts}
+            except socket.timeout:
+                result = {'status': 'error', 'msg': 'Timed out', 'ts': ts}
+            except OSError as exc:
+                result = {'status': 'error', 'msg': str(exc), 'ts': ts}
+            self._conn_health[conn_id] = result
+            GLib.idle_add(self._update_health_dot, conn_id)
+
+        _threading.Thread(target=_run, daemon=True).start()
+
+    def _update_health_dot(self, conn_id):
+        row = self._conn_mgr_rows.get(conn_id)
+        if row and hasattr(row, '_health_dot'):
+            self._apply_health_dot(row._health_dot, self._conn_health.get(conn_id, {}))
+
+    def _on_check_all_health(self):
+        for conn in self._store.list():
+            self._check_health(conn)
+
+    # ── Connection import / export ────────────────────────────────────────────
+
+    def _on_export_pgpass_bulk(self):
+        import os
+        import stat
+        import tempfile
+        conns = self._store.list()
+        written = skipped_dup = skipped_no_pwd = skipped_tunnel = 0
+
+        pgpass_path = os.path.expanduser('~/.pgpass')
+        existing_lines = []
+        if os.path.exists(pgpass_path):
+            try:
+                with open(pgpass_path, encoding='utf-8') as f:
+                    existing_lines = f.read().splitlines()
+            except OSError as e:
+                self._show_toast(f'Could not read ~/.pgpass: {e}')
+                return
+
+        def _escape(s):
+            return str(s).replace('\\', '\\\\').replace(':', '\\:')
+
+        new_lines = list(existing_lines)
+        for conn in conns:
+            if conn.get('ssh_host') or conn.get('cloud_proxy_enabled'):
+                skipped_tunnel += 1
+                continue
+            try:
+                password = self._store.get_password(conn['id'])
+            except Exception:
+                skipped_no_pwd += 1
+                continue
+            if not password:
+                skipped_no_pwd += 1
+                continue
+            line = ':'.join([
+                _escape(conn['host']),
+                _escape(conn['port']),
+                '*',
+                _escape(conn['username']),
+                _escape(password),
+            ])
+            if line in new_lines:
+                skipped_dup += 1
+                continue
+            new_lines.append(line)
+            written += 1
+
+        if written == 0:
+            parts = [f'Nothing written to ~/.pgpass.']
+            if skipped_dup:
+                parts.append(f'{skipped_dup} already present.')
+            if skipped_no_pwd:
+                parts.append(f'{skipped_no_pwd} skipped (no password).')
+            if skipped_tunnel:
+                parts.append(f'{skipped_tunnel} skipped (SSH/proxy).')
+            self._show_toast(' '.join(parts))
+            return
+
+        tmp_path = None
+        try:
+            content = '\n'.join(new_lines) + '\n'
+            pgpass_dir = os.path.dirname(pgpass_path) or os.path.expanduser('~')
+            with tempfile.NamedTemporaryFile(
+                mode='w', encoding='utf-8', dir=pgpass_dir, delete=False,
+            ) as tmp:
+                tmp.write(content)
+                tmp_path = tmp.name
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, pgpass_path)
+            tmp_path = None
+        except OSError as e:
+            self._show_toast(f'Export failed: {e}')
+            return
+        finally:
+            if tmp_path:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
+        parts = [f'{written} {"entry" if written == 1 else "entries"} written to ~/.pgpass.']
+        if skipped_dup:
+            parts.append(f'{skipped_dup} skipped (duplicate).')
+        if skipped_no_pwd:
+            parts.append(f'{skipped_no_pwd} skipped (no password).')
+        if skipped_tunnel:
+            parts.append(f'{skipped_tunnel} skipped (SSH/proxy).')
+        self._show_toast(' '.join(parts))
+
+    def _on_export_connections_json(self):
+        def _do_export(include_passwords):
+            data = self._store.export_json(include_passwords=include_passwords)
+            file_dialog = Gtk.FileDialog()
+            file_dialog.set_title('Export Connections')
+            file_dialog.set_initial_name('connections.tusk-connections.json')
+            filter_json = Gtk.FileFilter()
+            filter_json.set_name('Tusk connection files (*.tusk-connections.json)')
+            filter_json.add_pattern('*.tusk-connections.json')
+            filters = Gio.ListStore.new(Gtk.FileFilter)
+            filters.append(filter_json)
+            file_dialog.set_filters(filters)
+            file_dialog.save(self, None, self._on_export_json_file_chosen, data)
+
+        dialog = Adw.AlertDialog(
+            heading='Export Connections',
+            body='Passwords are excluded by default. Including them in the export file is a security risk — do not share the file with others.',
+        )
+        dialog.add_response('cancel', 'Cancel')
+        dialog.add_response('without', 'Export Without Passwords')
+        dialog.add_response('with', 'Include Passwords')
+        dialog.set_response_appearance('with', Adw.ResponseAppearance.DESTRUCTIVE)
+        dialog.set_default_response('without')
+        dialog.set_close_response('cancel')
+        dialog.connect('response', lambda d, r: _do_export(r == 'with') if r != 'cancel' else None)
+        dialog.present(self)
+
+    def _on_export_json_file_chosen(self, file_dialog, result, data):
+        try:
+            gfile = file_dialog.save_finish(result)
+        except Exception:
+            return
+        import json as _json
+        try:
+            path = gfile.get_path()
+            tmp = path + '.tmp'
+            with open(tmp, 'w', encoding='utf-8') as f:
+                _json.dump(data, f, indent=2)
+            os.replace(tmp, path)
+            n = len(data.get('connections', []))
+            self._show_toast(f'{n} connection{"s" if n != 1 else ""} exported.')
+        except OSError as e:
+            self._show_toast(f'Export failed: {e}')
+
+    def _on_import_connections_json(self):
+        file_dialog = Gtk.FileDialog()
+        file_dialog.set_title('Import Connections')
+        filter_json = Gtk.FileFilter()
+        filter_json.set_name('Tusk connection files (*.tusk-connections.json)')
+        filter_json.add_pattern('*.tusk-connections.json')
+        filter_all = Gtk.FileFilter()
+        filter_all.set_name('All files')
+        filter_all.add_pattern('*')
+        filters = Gio.ListStore.new(Gtk.FileFilter)
+        filters.append(filter_json)
+        filters.append(filter_all)
+        file_dialog.set_filters(filters)
+        file_dialog.open(self, None, self._on_import_json_file_chosen)
+
+    def _on_import_json_file_chosen(self, file_dialog, result):
+        import json as _json
+        try:
+            gfile = file_dialog.open_finish(result)
+        except Exception:
+            return
+        try:
+            path = gfile.get_path()
+            with open(path, encoding='utf-8') as f:
+                data = _json.load(f)
+        except (OSError, ValueError) as e:
+            self._show_toast(f'Could not read file: {e}')
+            return
+        conns = data.get('connections', [])
+        tags = data.get('tags_registry', {})
+        if not conns:
+            self._show_toast('No connections found in file.')
+            return
+        from connections_import_dialog import ConnectionsImportDialog
+        existing_names = {c['name'] for c in self._store.list()}
+        dlg = ConnectionsImportDialog(conns, tags, existing_names)
+        dlg.connect('import-confirmed', self._on_import_json_confirmed)
+        dlg.present(self)
+
+    def _on_import_json_confirmed(self, _dlg, resolved_conns, tags_registry):
+        added, skipped = self._store.bulk_import(resolved_conns, tags_registry)
+        # Add new rows to UI for freshly imported connections
+        existing_ids = set(self._conn_mgr_rows.keys())
+        tags_reg = self._store.get_tags_registry()
+        for conn in self._store.list():
+            if conn['id'] not in existing_ids:
+                self._add_connection_row(conn, tags_registry=tags_reg)
+        self._refresh_tag_strip()
+        msg = f'{added} connection{"s" if added != 1 else ""} imported.'
+        if skipped:
+            msg += f' {skipped} skipped (already present).'
+        self._show_toast(msg)
+
+    def _on_cleanup_stale(self):
+        from stale_dialog import StaleConnectionsDialog
+        dlg = StaleConnectionsDialog(self._store, self._conn_health)
+        dlg.connect('connections-deleted', self._on_stale_connections_deleted)
+        dlg.present(self)
+
+    def _on_stale_connections_deleted(self, _dlg, conn_ids):
+        for conn_id in conn_ids:
+            try:
+                self._store.remove(conn_id)
+            except Exception:
+                pass
+            mgr_row = self._conn_mgr_rows.pop(conn_id, None)
+            if mgr_row:
+                self._mgr_list.remove(mgr_row)
+            pop_row = self._conn_popover_rows.pop(conn_id, None)
+            if pop_row:
+                self._conn_list.remove(pop_row)
+            self._conn_health.pop(conn_id, None)
+            if conn_id == self._active_conn_id:
+                self._set_active_conn(None)
+        n = len(conn_ids)
+        self._show_toast(f'{n} connection{"s" if n != 1 else ""} deleted.')
+
+    def _show_toast(self, msg, timeout=4):
+        toast = Adw.Toast(title=msg)
+        toast.set_timeout(timeout)
+        self._toast_overlay.add_toast(toast)
 
     # ── Table / file tabs ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- TCP health check per connection (3s timeout, threaded); SSH/proxy connections show a yellow tunnel indicator; coloured status dot on each manager row with tooltip showing last check time and error
- "Check all connections", bulk .pgpass export, JSON export/import, and "Clean up stale…" via a new ⋯ overflow menu in the connection manager toolbar
- Stale connection cleanup dialog: lists connections unused for N days (configurable in Preferences → Connections) or never connected; bulk-delete with confirmation
- JSON export/import (.tusk-connections.json): exports all fields + tags registry; passwords excluded by default with opt-in warning; import preview dialog with name-clash resolution (auto-rename with "(imported)" suffix)
- Bulk .pgpass export: deduplicates against existing file, skips SSH/proxy and passwordless connections, sets 0600 permissions, shows summary toast

## Issues
Closes #290
Closes #291
Closes #284
Closes #283

## Test plan
- Open ⋯ menu in connection manager → "Check all connections" — dots on rows should go green/red/yellow
- Right-click a connection → "Check connection" — single row updates
- SSH/proxy connection should show yellow dot immediately (no TCP attempt)
- ⋯ → "Export all to .pgpass…" — check ~/.pgpass updated, 0600 perms, toast shows counts
- ⋯ → "Export connections…" — file dialog, choose "Export Without Passwords", verify .tusk-connections.json written
- Import that file on same/another machine — preview dialog shows all connections; name clash shows "(imported)" rename
- Open Preferences → Connections → change stale threshold
- ⋯ → "Clean up stale…" — shows connections unused for that many days; delete selected, confirm rows disappear
- Keyring error during stale delete should show toast and leave row intact