### PR TITLE
feat: GCP Cloud SQL and AlloyDB discovery and import

### DIFF
--- a/src/db_browser.py
+++ b/src/db_browser.py
@@ -118,6 +118,13 @@ class DbBrowser(Gtk.Box):
             GObject.SignalFlags.RUN_FIRST, None,
             (GObject.TYPE_PYOBJECT,),  # conn
         ),
+        'proxy-not-found': (
+            GObject.SignalFlags.RUN_FIRST, None,
+            (str,),  # binary name, e.g. 'cloud-sql-proxy'
+        ),
+        'connection-failed': (
+            GObject.SignalFlags.RUN_FIRST, None, (),
+        ),
     }
 
     def __init__(self):
@@ -215,6 +222,7 @@ class DbBrowser(Gtk.Box):
         self._conn_error_label.add_css_class('caption')
         self._conn_error_label.add_css_class('error')
         self._conn_error_label.set_xalign(0)
+        self._conn_error_label.set_selectable(True)
         self._conn_error_label.set_wrap(True)
         self._conn_error_label.set_hexpand(True)
         self._conn_error_bar.append(self._conn_error_label)
@@ -509,7 +517,7 @@ class DbBrowser(Gtk.Box):
         """Call before load() after a schema rename so expansion state is preserved."""
         self._rename_hint = (old_schema, new_schema)
 
-    def load(self, conn):
+    def load(self, conn, initial_connect=False):
         self._load_gen += 1
         gen = self._load_gen
         self._last_conn = conn
@@ -536,9 +544,9 @@ class DbBrowser(Gtk.Box):
         self._store.append(None, [
             'content-loading-symbolic', 'Loading…', 'loading', conn, '', ''
         ])
-        threading.Thread(target=self._fetch_schema, args=(conn, gen), daemon=True).start()
+        threading.Thread(target=self._fetch_schema, args=(conn, gen, initial_connect), daemon=True).start()
 
-    def _fetch_schema(self, conn, gen):
+    def _fetch_schema(self, conn, gen, initial_connect=False):
         try:
             import psycopg
             from tunnel import open_db
@@ -718,7 +726,12 @@ class DbBrowser(Gtk.Box):
                           schema_warning, schemas_hidden, current_role_attrs, roles_list, gen)
 
         except Exception as e:
-            GLib.idle_add(self._show_error, _friendly_pg_error(e), gen)
+            from tunnel import ProxyNotFoundError
+            if isinstance(e, ProxyNotFoundError):
+                GLib.idle_add(self.emit, 'proxy-not-found', e.binary)
+                GLib.idle_add(self._show_error, str(e), gen, initial_connect)
+            else:
+                GLib.idle_add(self._show_error, _friendly_pg_error(e), gen, initial_connect)
 
     def _populate(self, conn, schema_items, all_databases,
                   schema_warning, schemas_hidden, current_role_attrs, roles_list, gen):
@@ -946,7 +959,7 @@ class DbBrowser(Gtk.Box):
         if pinned:
             self._expand_favourites()
 
-    def _show_error(self, error_msg, gen):
+    def _show_error(self, error_msg, gen, initial_connect=False):
         if gen != self._load_gen:
             return
         self._loading_spinner.stop()
@@ -956,6 +969,8 @@ class DbBrowser(Gtk.Box):
         self._search_bar.set_visible(False)
         self._conn_error_label.set_label(error_msg)
         self._conn_error_bar.set_visible(True)
+        if initial_connect:
+            self.emit('connection-failed')
 
     def get_loaded_schemas(self):
         """Return list of schema names currently loaded in the tree."""

--- a/src/gcp_discovery.py
+++ b/src/gcp_discovery.py
@@ -1,0 +1,324 @@
+"""GCP database discovery — Cloud SQL and AlloyDB via gcloud CLI.
+
+All public functions return plain dicts / strings and never touch GTK.
+The dialog (gcp_discovery_dialog.py) calls these from a background thread.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import uuid
+
+CERT_DIR = os.path.join(os.path.expanduser('~'), '.config', 'tusk', 'certs')
+
+
+# ── gcloud helpers ─────────────────────────────────────────────────────────────
+
+def gcloud_available():
+    """Return True if `gcloud` is on $PATH."""
+    return shutil.which('gcloud') is not None
+
+
+def _gcloud(*args, project=None):
+    """Run a gcloud command and return parsed JSON output.
+
+    Raises RuntimeError with a user-readable message on failure.
+    """
+    cmd = ['gcloud'] + list(args) + ['--format=json']
+    if project:
+        cmd += ['--project', project]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f'gcloud timed out running: {" ".join(cmd)}')
+    except FileNotFoundError:
+        raise RuntimeError('gcloud not found on $PATH.')
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise RuntimeError(stderr or f'gcloud exited with code {result.returncode}')
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f'Could not parse gcloud output: {e}')
+
+
+def _gcloud_value(*args, project=None):
+    """Run a gcloud command with --format=value(...) and return stripped output."""
+    cmd = ['gcloud'] + list(args)
+    if project:
+        cmd += ['--project', project]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError('gcloud timed out.')
+    except FileNotFoundError:
+        raise RuntimeError('gcloud not found on $PATH.')
+    return result.stdout.strip()
+
+
+def get_active_project():
+    """Return the currently configured gcloud project, or None."""
+    val = _gcloud_value('config', 'get-value', 'project')
+    return val if val and val != '(unset)' else None
+
+
+def get_active_account():
+    """Return the active gcloud account email, or None if not authenticated."""
+    try:
+        accounts = _gcloud('auth', 'list', '--filter=status:ACTIVE')
+        if accounts:
+            return accounts[0].get('account')
+    except RuntimeError:
+        pass
+    return None
+
+
+# ── Cloud SQL discovery ────────────────────────────────────────────────────────
+
+def discover_cloud_sql(project):
+    """Return a list of Cloud SQL PostgreSQL instance dicts for the project."""
+    instances = _gcloud(
+        'sql', 'instances', 'list',
+        '--filter=databaseVersion:POSTGRES*',
+        project=project,
+    )
+    return instances if isinstance(instances, list) else []
+
+
+def fetch_cloud_sql_server_ca(instance_name, project):
+    """Fetch the server CA cert PEM for a Cloud SQL instance.
+
+    Writes the cert to CERT_DIR and returns the file path, or None on failure.
+    """
+    try:
+        pem = _gcloud_value(
+            'sql', 'instances', 'describe', instance_name,
+            '--format=value(serverCaCert.cert)',
+            project=project,
+        )
+        if not pem:
+            return None
+        os.makedirs(CERT_DIR, exist_ok=True)
+        cert_path = os.path.join(CERT_DIR, f'cloudsql-{project}-{instance_name}.pem')
+        with open(cert_path, 'w') as f:
+            f.write(pem)
+        return cert_path
+    except Exception:
+        return None
+
+
+def _has_public_ip(instance):
+    """Return True if the Cloud SQL instance has a public IP address."""
+    for ip in instance.get('ipAddresses', []):
+        if ip.get('type') == 'PRIMARY':
+            return True
+    return False
+
+
+def _iam_auth_enabled(instance):
+    """Return True if the Cloud SQL instance has IAM database authentication on."""
+    for flag in instance.get('settings', {}).get('databaseFlags', []):
+        if flag.get('name') == 'cloudsql.iam_authentication' and flag.get('value') == 'on':
+            return True
+    return False
+
+
+def build_cloud_sql_conn(instance, project, fetch_cert=True):
+    """Convert a Cloud SQL instance dict into a Tusk connection dict."""
+    name = instance.get('name', '')
+    region = instance.get('region', '')
+    db_version = instance.get('databaseVersion', '')  # e.g. POSTGRES_15
+    connection_name = instance.get('connectionName', f'{project}:{region}:{name}')
+
+    has_pub_ip = _has_public_ip(instance)
+    proxy_enabled = not has_pub_ip
+    iam_enabled = _iam_auth_enabled(instance)
+
+    # Pick a reachable host: public IP if available, else localhost (proxy)
+    host = 'localhost'
+    for ip in instance.get('ipAddresses', []):
+        if ip.get('type') == 'PRIMARY':
+            host = ip['ipAddress']
+            break
+
+    cert_path = None
+    if fetch_cert:
+        cert_path = fetch_cloud_sql_server_ca(name, project)
+
+    tags = ['gcp']
+    if region:
+        tags.append(region)
+
+    conn = {
+        'id': str(uuid.uuid4()),
+        'name': f'{name} (Cloud SQL)',
+        'host': host,
+        'port': 5432,
+        'database': 'postgres',
+        'username': '',
+        'cloud_provider': 'gcp-cloudsql',
+        'cloud_instance_id': connection_name,
+        'cloud_region': region,
+        'cloud_auth_mode': 'iam' if iam_enabled else 'password',
+        'cloud_proxy_enabled': proxy_enabled,
+        'cloud_proxy_port': None,
+        'ssl_mode': 'require',
+        'ssl_root_cert': cert_path,
+        'tags': tags,
+        '_gcp_service': 'Cloud SQL',
+        '_gcp_version': db_version,
+        '_gcp_region': region,
+    }
+    return conn
+
+
+# ── AlloyDB discovery ──────────────────────────────────────────────────────────
+
+def discover_alloydb(project):
+    """Return a list of (cluster, instance) tuples for AlloyDB primary instances."""
+    try:
+        clusters = _gcloud('alloydb', 'clusters', 'list', '--region=-', project=project)
+    except RuntimeError:
+        return []
+    if not isinstance(clusters, list):
+        return []
+
+    results = []
+    for cluster in clusters:
+        cluster_id = cluster.get('name', '').split('/')[-1]
+        region = cluster.get('name', '').split('/')[-3] if '/' in cluster.get('name', '') else ''
+        try:
+            instances = _gcloud(
+                'alloydb', 'instances', 'list',
+                f'--cluster={cluster_id}',
+                f'--region={region}',
+                project=project,
+            )
+        except RuntimeError:
+            continue
+        if not isinstance(instances, list):
+            continue
+        for inst in instances:
+            # Primary instances only (exclude READ_POOL per issue spec)
+            if inst.get('instanceType') == 'PRIMARY':
+                results.append((cluster, inst))
+    return results
+
+
+def fetch_alloydb_server_ca(cluster_name, project):
+    """Fetch the server CA cert PEM for an AlloyDB cluster.
+
+    Writes the cert to CERT_DIR and returns the file path, or None on failure.
+    """
+    try:
+        pem = _gcloud_value(
+            'alloydb', 'clusters', 'describe', cluster_name,
+            '--region=-',
+            '--format=value(sslConfig.caSource)',
+            project=project,
+        )
+        # sslConfig.caSource is not the cert itself — AlloyDB uses a managed CA.
+        # Fetch via the REST equivalent if available; otherwise skip.
+        if not pem:
+            return None
+        os.makedirs(CERT_DIR, exist_ok=True)
+        cert_path = os.path.join(CERT_DIR, f'alloydb-{project}-{cluster_name}.pem')
+        with open(cert_path, 'w') as f:
+            f.write(pem)
+        return cert_path
+    except Exception:
+        return None
+
+
+def _alloydb_has_public_ip(instance):
+    """Return True if the AlloyDB instance has a public IP address."""
+    network_config = instance.get('networkConfig', {})
+    # If publicIpAddress is set and non-empty, there's a public endpoint
+    return bool(instance.get('publicIpAddress'))
+
+
+def build_alloydb_conn(cluster, instance, project, fetch_cert=True):
+    """Convert an AlloyDB (cluster, instance) pair into a Tusk connection dict."""
+    cluster_id = cluster.get('name', '').split('/')[-1]
+    region = cluster.get('name', '').split('/')[-3] if '/' in cluster.get('name', '') else ''
+    instance_id = instance.get('name', '').split('/')[-1]
+
+    has_pub_ip = _alloydb_has_public_ip(instance)
+    proxy_enabled = not has_pub_ip
+
+    # Public IP if available, else localhost (proxy)
+    host = instance.get('publicIpAddress') or 'localhost'
+    if proxy_enabled:
+        host = 'localhost'
+
+    # AlloyDB instance URI for Auth Proxy: projects/PROJECT/locations/REGION/clusters/CLUSTER/instances/INSTANCE
+    instance_uri = instance.get('name', '')
+
+    cert_path = None
+    if fetch_cert:
+        cert_path = fetch_alloydb_server_ca(cluster_id, project)
+
+    tags = ['gcp']
+    if region:
+        tags.append(region)
+
+    conn = {
+        'id': str(uuid.uuid4()),
+        'name': f'{cluster_id}/{instance_id} (AlloyDB)',
+        'host': host,
+        'port': 5432,
+        'database': 'postgres',
+        'username': '',
+        'cloud_provider': 'gcp-alloydb',
+        'cloud_instance_id': instance_uri,
+        'cloud_region': region,
+        'cloud_auth_mode': 'iam',   # AlloyDB defaults to IAM auth
+        'cloud_proxy_enabled': proxy_enabled,
+        'cloud_proxy_port': None,
+        'ssl_mode': 'require',
+        'ssl_root_cert': cert_path,
+        'tags': tags,
+        '_gcp_service': 'AlloyDB',
+        '_gcp_version': 'AlloyDB',
+        '_gcp_region': region,
+    }
+    return conn
+
+
+# ── IAM token helper ───────────────────────────────────────────────────────────
+
+def get_iam_token():
+    """Return a fresh access token from gcloud for IAM database authentication.
+
+    Raises RuntimeError if gcloud is unavailable or authentication fails.
+    """
+    try:
+        result = subprocess.run(
+            ['gcloud', 'auth', 'print-access-token'],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except FileNotFoundError:
+        raise RuntimeError('gcloud not found on $PATH.')
+    except subprocess.TimeoutExpired:
+        raise RuntimeError('gcloud auth print-access-token timed out.')
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or 'gcloud auth print-access-token failed.')
+    token = result.stdout.strip()
+    if not token:
+        raise RuntimeError('gcloud returned an empty access token.')
+    return token

--- a/src/gcp_discovery.py
+++ b/src/gcp_discovery.py
@@ -66,12 +66,17 @@ def _gcloud_value(*args, project=None):
         raise RuntimeError('gcloud timed out.')
     except FileNotFoundError:
         raise RuntimeError('gcloud not found on $PATH.')
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f'gcloud exited with code {result.returncode}')
     return result.stdout.strip()
 
 
 def get_active_project():
     """Return the currently configured gcloud project, or None."""
-    val = _gcloud_value('config', 'get-value', 'project')
+    try:
+        val = _gcloud_value('config', 'get-value', 'project')
+    except RuntimeError:
+        return None
     return val if val and val != '(unset)' else None
 
 
@@ -98,19 +103,18 @@ def discover_cloud_sql(project):
     return instances if isinstance(instances, list) else []
 
 
-def fetch_cloud_sql_server_ca(instance_name, project):
-    """Fetch the server CA cert PEM for a Cloud SQL instance.
+def save_cloud_sql_server_ca(instance, project):
+    """Extract the server CA cert from the instance dict and write it to disk.
 
-    Writes the cert to CERT_DIR and returns the file path, or None on failure.
+    The cert is already present in the instances list response under
+    instance['serverCaCert']['cert'], so no extra gcloud call is needed.
+    Returns the file path, or None if the cert is missing/write fails.
     """
     try:
-        pem = _gcloud_value(
-            'sql', 'instances', 'describe', instance_name,
-            '--format=value(serverCaCert.cert)',
-            project=project,
-        )
+        pem = instance.get('serverCaCert', {}).get('cert', '')
         if not pem:
             return None
+        instance_name = instance.get('name', 'unknown')
         os.makedirs(CERT_DIR, exist_ok=True)
         cert_path = os.path.join(CERT_DIR, f'cloudsql-{project}-{instance_name}.pem')
         with open(cert_path, 'w') as f:
@@ -154,9 +158,7 @@ def build_cloud_sql_conn(instance, project, fetch_cert=True):
             host = ip['ipAddress']
             break
 
-    cert_path = None
-    if fetch_cert:
-        cert_path = fetch_cloud_sql_server_ca(name, project)
+    cert_path = save_cloud_sql_server_ca(instance, project) if fetch_cert else None
 
     tags = ['gcp']
     if region:
@@ -168,7 +170,7 @@ def build_cloud_sql_conn(instance, project, fetch_cert=True):
         'host': host,
         'port': 5432,
         'database': 'postgres',
-        'username': '',
+        'username': 'postgres',
         'cloud_provider': 'gcp-cloudsql',
         'cloud_instance_id': connection_name,
         'cloud_region': region,
@@ -245,8 +247,6 @@ def fetch_alloydb_server_ca(cluster_name, project):
 
 def _alloydb_has_public_ip(instance):
     """Return True if the AlloyDB instance has a public IP address."""
-    network_config = instance.get('networkConfig', {})
-    # If publicIpAddress is set and non-empty, there's a public endpoint
     return bool(instance.get('publicIpAddress'))
 
 
@@ -261,8 +261,6 @@ def build_alloydb_conn(cluster, instance, project, fetch_cert=True):
 
     # Public IP if available, else localhost (proxy)
     host = instance.get('publicIpAddress') or 'localhost'
-    if proxy_enabled:
-        host = 'localhost'
 
     # AlloyDB instance URI for Auth Proxy: projects/PROJECT/locations/REGION/clusters/CLUSTER/instances/INSTANCE
     instance_uri = instance.get('name', '')
@@ -281,7 +279,7 @@ def build_alloydb_conn(cluster, instance, project, fetch_cert=True):
         'host': host,
         'port': 5432,
         'database': 'postgres',
-        'username': '',
+        'username': 'postgres',
         'cloud_provider': 'gcp-alloydb',
         'cloud_instance_id': instance_uri,
         'cloud_region': region,

--- a/src/gcp_discovery.py
+++ b/src/gcp_discovery.py
@@ -15,6 +15,30 @@ CERT_DIR = os.path.join(os.path.expanduser('~'), '.config', 'tusk', 'certs')
 
 # ── gcloud helpers ─────────────────────────────────────────────────────────────
 
+def _friendly_gcloud_error(stderr, fallback):
+    """Return a user-readable error message for a failed gcloud command.
+
+    Detects common failure patterns (API not enabled, permission denied) and
+    replaces the raw gcloud stderr with actionable guidance.
+    """
+    detail = stderr or fallback
+    low = detail.lower()
+    if 'has not been used' in low or 'is disabled' in low or 'enable it by visiting' in low:
+        # Extract the API name if present (e.g. sqladmin.googleapis.com)
+        api = ''
+        for word in detail.split():
+            if 'googleapis.com' in word:
+                api = word.strip('[].,')
+                break
+        msg = 'A required GCP API is not enabled on this project.'
+        if api:
+            msg += f'\n\nEnable it in the GCP console:\nhttps://console.cloud.google.com/apis/library/{api}'
+        else:
+            msg += '\n\nOpen the GCP console → APIs & Services → Enable APIs and Services.'
+        return msg
+    return detail
+
+
 def gcloud_available():
     """Return True if `gcloud` is on $PATH."""
     return shutil.which('gcloud') is not None
@@ -41,8 +65,8 @@ def _gcloud(*args, project=None):
         raise RuntimeError('gcloud not found on $PATH.')
 
     if result.returncode != 0:
-        stderr = result.stderr.strip()
-        raise RuntimeError(stderr or f'gcloud exited with code {result.returncode}')
+        raise RuntimeError(_friendly_gcloud_error(result.stderr.strip(),
+                                                   f'gcloud exited with code {result.returncode}'))
 
     try:
         return json.loads(result.stdout)
@@ -190,11 +214,12 @@ def build_cloud_sql_conn(instance, project, fetch_cert=True):
 # ── AlloyDB discovery ──────────────────────────────────────────────────────────
 
 def discover_alloydb(project):
-    """Return a list of (cluster, instance) tuples for AlloyDB primary instances."""
-    try:
-        clusters = _gcloud('alloydb', 'clusters', 'list', '--region=-', project=project)
-    except RuntimeError:
-        return []
+    """Return a list of (cluster, instance) tuples for AlloyDB primary instances.
+
+    Raises RuntimeError if the initial cluster list fails (auth error, API disabled, etc.).
+    Per-cluster instance listing errors are silently skipped so a partial list is returned.
+    """
+    clusters = _gcloud('alloydb', 'clusters', 'list', '--region=-', project=project)
     if not isinstance(clusters, list):
         return []
 
@@ -221,28 +246,13 @@ def discover_alloydb(project):
 
 
 def fetch_alloydb_server_ca(cluster_name, project):
-    """Fetch the server CA cert PEM for an AlloyDB cluster.
+    """Return the AlloyDB server CA cert path, or None.
 
-    Writes the cert to CERT_DIR and returns the file path, or None on failure.
+    AlloyDB uses a Google-managed CA that is trusted by the system root store,
+    so no custom ssl_root_cert is needed. psycopg will validate against system
+    CAs when ssl_mode='require'. Returns None to leave ssl_root_cert unset.
     """
-    try:
-        pem = _gcloud_value(
-            'alloydb', 'clusters', 'describe', cluster_name,
-            '--region=-',
-            '--format=value(sslConfig.caSource)',
-            project=project,
-        )
-        # sslConfig.caSource is not the cert itself — AlloyDB uses a managed CA.
-        # Fetch via the REST equivalent if available; otherwise skip.
-        if not pem:
-            return None
-        os.makedirs(CERT_DIR, exist_ok=True)
-        cert_path = os.path.join(CERT_DIR, f'alloydb-{project}-{cluster_name}.pem')
-        with open(cert_path, 'w') as f:
-            f.write(pem)
-        return cert_path
-    except Exception:
-        return None
+    return None
 
 
 def _alloydb_has_public_ip(instance):

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -1,0 +1,304 @@
+import threading
+
+import gi
+
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+
+from gi.repository import Gtk, Adw, GObject, GLib
+
+import gcp_discovery
+
+
+class GcpDiscoveryDialog(Adw.Dialog):
+    """Discover and import GCP Cloud SQL / AlloyDB PostgreSQL instances.
+
+    Emits 'import-confirmed' with a list of connection dicts when the user
+    clicks Import Selected.
+    """
+
+    __gsignals__ = {
+        'import-confirmed': (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+    }
+
+    def __init__(self, existing_instance_ids=None):
+        super().__init__(title='Import from GCP', content_width=540, content_height=580)
+        self._existing_ids = set(existing_instance_ids or [])
+        self._conns = []   # discovered connection dicts with internal _gcp_* keys
+        self._checks = {}  # idx → (Gtk.CheckButton, conn_dict)
+        self._project = None
+        self._build_ui()
+
+    # ── UI skeleton ────────────────────────────────────────────────────────────
+
+    def _build_ui(self):
+        self._header = Adw.HeaderBar()
+
+        self._stack = Gtk.Stack()
+        self._stack.set_transition_type(Gtk.StackTransitionType.CROSSFADE)
+
+        # Page: checking gcloud
+        self._loading_page = self._build_loading_page('Checking gcloud…')
+        self._stack.add_named(self._loading_page, 'loading')
+
+        # Page: project entry (shown if no active project)
+        self._project_page = self._build_project_page()
+        self._stack.add_named(self._project_page, 'project')
+
+        # Page: discovery results
+        self._results_page = self._build_results_page()
+        self._stack.add_named(self._results_page, 'results')
+
+        # Page: error
+        self._error_page = self._build_error_page()
+        self._stack.add_named(self._error_page, 'error')
+
+        toolbar_view = Adw.ToolbarView()
+        toolbar_view.add_top_bar(self._header)
+        toolbar_view.set_content(self._stack)
+        self.set_child(toolbar_view)
+
+        # Start checking gcloud availability
+        threading.Thread(target=self._check_gcloud, daemon=True).start()
+
+    def _build_loading_page(self, label_text):
+        spinner = Gtk.Spinner()
+        spinner.set_size_request(32, 32)
+        spinner.start()
+        label = Gtk.Label(label=label_text)
+        label.add_css_class('dim-label')
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_halign(Gtk.Align.CENTER)
+        box.set_valign(Gtk.Align.CENTER)
+        box.set_vexpand(True)
+        box.append(spinner)
+        box.append(label)
+        return box
+
+    def _build_project_page(self):
+        group = Adw.PreferencesGroup(
+            title='GCP Project',
+            description='No active project found. Enter the GCP project ID to discover databases in.',
+        )
+        self._project_entry = Adw.EntryRow(title='Project ID')
+        group.add(self._project_entry)
+
+        discover_btn = Gtk.Button(label='Discover Databases')
+        discover_btn.add_css_class('suggested-action')
+        discover_btn.add_css_class('pill')
+        discover_btn.set_halign(Gtk.Align.CENTER)
+        discover_btn.connect('clicked', self._on_project_confirm)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
+        box.set_margin_top(20)
+        box.set_margin_bottom(20)
+        box.set_margin_start(20)
+        box.set_margin_end(20)
+        box.set_valign(Gtk.Align.CENTER)
+        box.set_vexpand(True)
+        box.append(group)
+        box.append(discover_btn)
+        return box
+
+    def _build_results_page(self):
+        self._summary_label = Gtk.Label()
+        self._summary_label.add_css_class('dim-label')
+        self._summary_label.set_wrap(True)
+        self._summary_label.set_xalign(0)
+
+        self._results_list = Gtk.ListBox()
+        self._results_list.add_css_class('boxed-list')
+        self._results_list.set_selection_mode(Gtk.SelectionMode.NONE)
+
+        self._import_btn = Gtk.Button(label='Import Selected')
+        self._import_btn.add_css_class('suggested-action')
+        self._import_btn.add_css_class('pill')
+        self._import_btn.set_halign(Gtk.Align.CENTER)
+        self._import_btn.connect('clicked', self._on_import)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_margin_top(16)
+        box.set_margin_bottom(20)
+        box.set_margin_start(20)
+        box.set_margin_end(20)
+        box.append(self._summary_label)
+        box.append(self._results_list)
+        box.append(self._import_btn)
+
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_propagate_natural_height(True)
+        scroll.set_child(box)
+        return scroll
+
+    def _build_error_page(self):
+        self._error_status = Adw.StatusPage(
+            icon_name='dialog-error-symbolic',
+            title='Discovery Failed',
+        )
+        return self._error_status
+
+    # ── Background checks ──────────────────────────────────────────────────────
+
+    def _check_gcloud(self):
+        if not gcp_discovery.gcloud_available():
+            GLib.idle_add(self._show_error,
+                'gcloud not found',
+                'Install the Google Cloud CLI and run `gcloud auth login` before using this feature.\n\n'
+                'Download: https://cloud.google.com/sdk/docs/install')
+            return
+
+        account = gcp_discovery.get_active_account()
+        if not account:
+            GLib.idle_add(self._show_error,
+                'Not authenticated',
+                'No active gcloud credentials found.\n\nRun `gcloud auth login` in a terminal and try again.')
+            return
+
+        project = gcp_discovery.get_active_project()
+        GLib.idle_add(self._on_gcloud_ready, project)
+
+    def _on_gcloud_ready(self, project):
+        if project:
+            self._project = project
+            self._start_discovery(project)
+        else:
+            self._stack.set_visible_child_name('project')
+
+    def _on_project_confirm(self, _btn):
+        project = self._project_entry.get_text().strip()
+        if not project:
+            self._project_entry.add_css_class('error')
+            return
+        self._project_entry.remove_css_class('error')
+        self._project = project
+
+        # Replace project page with a loading spinner
+        loading = self._build_loading_page(f'Discovering databases in {project}…')
+        self._stack.add_named(loading, 'loading2')
+        self._stack.set_visible_child_name('loading2')
+        self._start_discovery(project)
+
+    def _start_discovery(self, project):
+        loading = self._build_loading_page(f'Discovering databases in {project}…')
+        existing = self._stack.get_child_by_name('loading_discovery')
+        if existing:
+            self._stack.remove(existing)
+        self._stack.add_named(loading, 'loading_discovery')
+        self._stack.set_visible_child_name('loading_discovery')
+        threading.Thread(target=self._run_discovery, args=(project,), daemon=True).start()
+
+    def _run_discovery(self, project):
+        conns = []
+        errors = []
+
+        # Cloud SQL
+        try:
+            instances = gcp_discovery.discover_cloud_sql(project)
+            for inst in instances:
+                conn = gcp_discovery.build_cloud_sql_conn(inst, project, fetch_cert=True)
+                conns.append(conn)
+        except RuntimeError as e:
+            errors.append(f'Cloud SQL: {e}')
+
+        # AlloyDB
+        try:
+            pairs = gcp_discovery.discover_alloydb(project)
+            for cluster, inst in pairs:
+                conn = gcp_discovery.build_alloydb_conn(cluster, inst, project, fetch_cert=True)
+                conns.append(conn)
+        except RuntimeError as e:
+            errors.append(f'AlloyDB: {e}')
+
+        GLib.idle_add(self._show_results, conns, errors)
+
+    # ── Results rendering ──────────────────────────────────────────────────────
+
+    def _show_results(self, conns, errors):
+        self._conns = conns
+        self._checks = {}
+
+        # Clear existing rows
+        while True:
+            row = self._results_list.get_first_child()
+            if row is None:
+                break
+            self._results_list.remove(row)
+
+        if not conns:
+            msg = 'No PostgreSQL instances found in this project.'
+            if errors:
+                msg += '\n\nErrors:\n' + '\n'.join(errors)
+            self._show_error('No instances found', msg)
+            return
+
+        # Group by service then region
+        groups = {}  # (service, region) → [conn]
+        for conn in conns:
+            key = (conn.get('_gcp_service', ''), conn.get('_gcp_region', ''))
+            groups.setdefault(key, []).append(conn)
+
+        idx = 0
+        for (service, region), group_conns in sorted(groups.items()):
+            # Section header row
+            header_row = Adw.ActionRow(
+                title=f'{service} — {region}' if region else service,
+            )
+            header_row.set_activatable(False)
+            header_row.add_css_class('dim-label')
+            self._results_list.append(header_row)
+
+            for conn in group_conns:
+                already = conn.get('cloud_instance_id', '') in self._existing_ids
+                row = Adw.ActionRow(title=conn['name'])
+                subtitle_parts = [conn.get('_gcp_version', '')]
+                if conn.get('cloud_proxy_enabled'):
+                    subtitle_parts.append('Auth Proxy')
+                if conn.get('cloud_auth_mode') == 'iam':
+                    subtitle_parts.append('IAM auth')
+                if already:
+                    subtitle_parts.append('Already imported')
+                row.set_subtitle(' · '.join(p for p in subtitle_parts if p))
+                row.set_sensitive(not already)
+
+                check = Gtk.CheckButton()
+                check.set_active(not already)
+                check.set_sensitive(not already)
+                check.set_valign(Gtk.Align.CENTER)
+                row.add_suffix(check)
+                row.set_activatable_widget(check)
+                self._results_list.append(row)
+                self._checks[idx] = (check, conn)
+                idx += 1
+
+        total = len(conns)
+        already_count = sum(
+            1 for c in conns if c.get('cloud_instance_id', '') in self._existing_ids
+        )
+        summary = f'{total} instance{"s" if total != 1 else ""} found.'
+        if already_count:
+            summary += f' {already_count} already imported.'
+        if errors:
+            summary += f' (Errors: {"; ".join(errors)})'
+        self._summary_label.set_text(summary)
+
+        self._stack.set_visible_child_name('results')
+
+    def _show_error(self, title, description):
+        self._error_status.set_title(title)
+        self._error_status.set_description(description)
+        self._stack.set_visible_child_name('error')
+
+    # ── Import ─────────────────────────────────────────────────────────────────
+
+    def _on_import(self, _btn):
+        selected = [
+            conn for (check, conn) in self._checks.values()
+            if check.get_active()
+        ]
+        if not selected:
+            return
+        # Strip internal _gcp_* keys before emitting
+        clean = [{k: v for k, v in c.items() if not k.startswith('_gcp_')} for c in selected]
+        self.emit('import-confirmed', clean)
+        self.close()

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -1,3 +1,4 @@
+import shutil
 import threading
 
 import gi
@@ -37,8 +38,10 @@ class GcpDiscoveryDialog(Adw.Dialog):
         self._stack = Gtk.Stack()
         self._stack.set_transition_type(Gtk.StackTransitionType.CROSSFADE)
 
-        # Page: checking gcloud
-        self._loading_page = self._build_loading_page('Checking gcloud…')
+        # Page: checking gcloud / discovering
+        self._loading_label_widget = Gtk.Label(label='Checking gcloud…')
+        self._loading_label_widget.add_css_class('dim-label')
+        self._loading_page = self._build_loading_page_with_label(self._loading_label_widget)
         self._stack.add_named(self._loading_page, 'loading')
 
         # Page: project entry (shown if no active project)
@@ -61,19 +64,22 @@ class GcpDiscoveryDialog(Adw.Dialog):
         # Start checking gcloud availability
         threading.Thread(target=self._check_gcloud, daemon=True).start()
 
-    def _build_loading_page(self, label_text):
+    def _build_loading_page_with_label(self, label_widget):
         spinner = Gtk.Spinner()
         spinner.set_size_request(32, 32)
         spinner.start()
-        label = Gtk.Label(label=label_text)
-        label.add_css_class('dim-label')
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
         box.set_halign(Gtk.Align.CENTER)
         box.set_valign(Gtk.Align.CENTER)
         box.set_vexpand(True)
         box.append(spinner)
-        box.append(label)
+        box.append(label_widget)
         return box
+
+    def _build_loading_page(self, label_text):
+        label = Gtk.Label(label=label_text)
+        label.add_css_class('dim-label')
+        return self._build_loading_page_with_label(label)
 
     def _build_project_page(self):
         group = Adw.PreferencesGroup(
@@ -106,6 +112,13 @@ class GcpDiscoveryDialog(Adw.Dialog):
         self._summary_label.set_wrap(True)
         self._summary_label.set_xalign(0)
 
+        self._proxy_banner = Adw.Banner(
+            title='Cloud SQL Auth Proxy required for some instances — install it before connecting.',
+            button_label='How to install',
+        )
+        self._proxy_banner.set_revealed(False)
+        self._proxy_banner.connect('button-clicked', self._on_proxy_banner_clicked)
+
         self._results_list = Gtk.ListBox()
         self._results_list.add_css_class('boxed-list')
         self._results_list.set_selection_mode(Gtk.SelectionMode.NONE)
@@ -121,6 +134,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
         box.set_margin_bottom(20)
         box.set_margin_start(20)
         box.set_margin_end(20)
+        box.append(self._proxy_banner)
         box.append(self._summary_label)
         box.append(self._results_list)
         box.append(self._import_btn)
@@ -172,20 +186,11 @@ class GcpDiscoveryDialog(Adw.Dialog):
             return
         self._project_entry.remove_css_class('error')
         self._project = project
-
-        # Replace project page with a loading spinner
-        loading = self._build_loading_page(f'Discovering databases in {project}…')
-        self._stack.add_named(loading, 'loading2')
-        self._stack.set_visible_child_name('loading2')
         self._start_discovery(project)
 
     def _start_discovery(self, project):
-        loading = self._build_loading_page(f'Discovering databases in {project}…')
-        existing = self._stack.get_child_by_name('loading_discovery')
-        if existing:
-            self._stack.remove(existing)
-        self._stack.add_named(loading, 'loading_discovery')
-        self._stack.set_visible_child_name('loading_discovery')
+        self._loading_label_widget.set_text(f'Discovering databases in {project}…')
+        self._stack.set_visible_child_name('loading')
         threading.Thread(target=self._run_discovery, args=(project,), daemon=True).start()
 
     def _run_discovery(self, project):
@@ -282,12 +287,28 @@ class GcpDiscoveryDialog(Adw.Dialog):
             summary += f' (Errors: {"; ".join(errors)})'
         self._summary_label.set_text(summary)
 
+        # Show proxy banner if any instances need the proxy and it's not installed
+        needs_proxy = any(c.get('cloud_proxy_enabled') for c in conns)
+        proxy_missing = needs_proxy and not shutil.which('cloud-sql-proxy')
+        self._proxy_banner.set_revealed(proxy_missing)
+
         self._stack.set_visible_child_name('results')
 
     def _show_error(self, title, description):
         self._error_status.set_title(title)
         self._error_status.set_description(description)
         self._stack.set_visible_child_name('error')
+
+    def _on_proxy_banner_clicked(self, _banner):
+        install_url = 'https://cloud.google.com/sql/docs/postgres/sql-proxy#install'
+        dialog = Adw.AlertDialog(
+            heading='Install Cloud SQL Auth Proxy',
+            body=f'See the installation guide for the latest download:\n\n{install_url}',
+        )
+        dialog.add_response('ok', 'OK')
+        dialog.set_default_response('ok')
+        dialog.set_close_response('ok')
+        dialog.present(self)
 
     # ── Import ─────────────────────────────────────────────────────────────────
 

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -28,6 +28,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
         self._conns = []   # discovered connection dicts with internal _gcp_* keys
         self._checks = {}  # idx → (Gtk.CheckButton, conn_dict)
         self._project = None
+        self._missing_proxy_binaries = set()
         self._build_ui()
 
     # ── UI skeleton ────────────────────────────────────────────────────────────
@@ -287,10 +288,31 @@ class GcpDiscoveryDialog(Adw.Dialog):
             summary += f' (Errors: {"; ".join(errors)})'
         self._summary_label.set_text(summary)
 
-        # Show proxy banner if any instances need the proxy and it's not installed
-        needs_proxy = any(c.get('cloud_proxy_enabled') for c in conns)
-        proxy_missing = needs_proxy and not shutil.which('cloud-sql-proxy')
-        self._proxy_banner.set_revealed(proxy_missing)
+        # Show proxy banner if any instances need a proxy binary that isn't installed
+        _PROXY_BINARY = {
+            'gcp-cloudsql': 'cloud-sql-proxy',
+            'gcp-alloydb': 'alloydb-auth-proxy',
+        }
+        _PROXY_NAME = {
+            'cloud-sql-proxy': 'Cloud SQL Auth Proxy',
+            'alloydb-auth-proxy': 'AlloyDB Auth Proxy',
+        }
+        self._missing_proxy_binaries = {
+            _PROXY_BINARY[c['cloud_provider']]
+            for c in conns
+            if c.get('cloud_proxy_enabled') and c.get('cloud_provider') in _PROXY_BINARY
+            and not shutil.which(_PROXY_BINARY[c['cloud_provider']])
+        }
+        if self._missing_proxy_binaries:
+            names = ' and '.join(
+                _PROXY_NAME.get(b, b) for b in sorted(self._missing_proxy_binaries)
+            )
+            self._proxy_banner.set_title(
+                f'{names} required for some instances — install before connecting.'
+            )
+            self._proxy_banner.set_revealed(True)
+        else:
+            self._proxy_banner.set_revealed(False)
 
         self._stack.set_visible_child_name('results')
 
@@ -300,10 +322,19 @@ class GcpDiscoveryDialog(Adw.Dialog):
         self._stack.set_visible_child_name('error')
 
     def _on_proxy_banner_clicked(self, _banner):
-        install_url = 'https://cloud.google.com/sql/docs/postgres/sql-proxy#install'
+        _INSTALL_URLS = {
+            'cloud-sql-proxy': ('Cloud SQL Auth Proxy',
+                                'https://cloud.google.com/sql/docs/postgres/sql-proxy#install'),
+            'alloydb-auth-proxy': ('AlloyDB Auth Proxy',
+                                   'https://cloud.google.com/alloydb/docs/auth-proxy/connect#install-proxy'),
+        }
+        missing = getattr(self, '_missing_proxy_binaries', {'cloud-sql-proxy'})
+        lines = [f'{name}:\n{url}' for b in sorted(missing)
+                 for name, url in [_INSTALL_URLS.get(b, (b, ''))]]
+        heading = 'Install Required Proxy' if len(missing) == 1 else 'Install Required Proxies'
         dialog = Adw.AlertDialog(
-            heading='Install Cloud SQL Auth Proxy',
-            body=f'See the installation guide for the latest download:\n\n{install_url}',
+            heading=heading,
+            body='See the installation guides for the latest downloads:\n\n' + '\n\n'.join(lines),
         )
         dialog.add_response('ok', 'OK')
         dialog.set_default_response('ok')

--- a/src/tunnel.py
+++ b/src/tunnel.py
@@ -7,6 +7,15 @@ import time
 from contextlib import contextmanager
 
 
+class ProxyNotFoundError(RuntimeError):
+    """Raised when a cloud proxy binary is required but not on $PATH."""
+    def __init__(self, binary):
+        self.binary = binary
+        super().__init__(
+            f'{binary} not found on $PATH — install it to connect to this instance.'
+        )
+
+
 def _free_port():
     with socket.socket() as s:
         s.bind(('127.0.0.1', 0))
@@ -63,8 +72,12 @@ def apply_conn_settings(db, conn):
     db.commit()
 
 
-def _psycopg_kwargs(conn, host, port, password=None):
-    """Build psycopg.connect keyword arguments from a connection profile."""
+def _psycopg_kwargs(conn, host, port, password=None, skip_ssl=False):
+    """Build psycopg.connect keyword arguments from a connection profile.
+
+    skip_ssl should be True when connecting through a cloud proxy — the proxy
+    handles SSL to Cloud SQL internally; the local psycopg→proxy leg is plain TCP.
+    """
     kwargs = dict(
         host=host,
         port=port,
@@ -73,12 +86,13 @@ def _psycopg_kwargs(conn, host, port, password=None):
         password=password if password is not None else conn.get('password', ''),
         connect_timeout=10,
     )
-    ssl_mode = conn.get('ssl_mode')
-    if ssl_mode and ssl_mode != 'prefer':
-        kwargs['sslmode'] = ssl_mode
-    ssl_root_cert = conn.get('ssl_root_cert')
-    if ssl_root_cert:
-        kwargs['sslrootcert'] = ssl_root_cert
+    if not skip_ssl:
+        ssl_mode = conn.get('ssl_mode')
+        if ssl_mode and ssl_mode != 'prefer':
+            kwargs['sslmode'] = ssl_mode
+        ssl_root_cert = conn.get('ssl_root_cert')
+        if ssl_root_cert:
+            kwargs['sslrootcert'] = ssl_root_cert
     return kwargs
 
 
@@ -105,7 +119,8 @@ def open_db(conn, autocommit=False):
         password = get_iam_token()
 
     with open_tunnel(conn) as (host, port), psycopg.connect(
-        **_psycopg_kwargs(conn, host, port, password=password)
+        **_psycopg_kwargs(conn, host, port, password=password,
+                          skip_ssl=conn.get('cloud_proxy_enabled', False))
     ) as db:
         apply_conn_settings(db, conn)
         if autocommit:
@@ -135,10 +150,7 @@ def _cloud_proxy_tunnel(conn):
         binary = 'cloud-sql-proxy'
 
     if not shutil.which(binary):
-        raise RuntimeError(
-            f'{binary} not found on $PATH. '
-            'Install it to connect to this instance.'
-        )
+        raise ProxyNotFoundError(binary)
 
     local_port = _free_port()
     cmd = [binary, instance_id, '--port', str(local_port)]
@@ -146,10 +158,49 @@ def _cloud_proxy_tunnel(conn):
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
         )
     except OSError as e:
         raise RuntimeError(f'Could not start {binary}: {e}')
+
+    # Capture stderr in a background thread so we don't miss lines emitted
+    # after startup (e.g. when proxy crashes mid-connection).
+    stderr_lines = []
+
+    def _capture_stderr():
+        try:
+            for raw in proc.stderr:
+                stderr_lines.append(raw.decode('utf-8', errors='replace').rstrip())
+        except Exception:
+            pass
+
+    stderr_thread = threading.Thread(target=_capture_stderr, daemon=True)
+    stderr_thread.start()
+
+    def _get_stderr():
+        stderr_thread.join(timeout=1)
+        return '\n'.join(stderr_lines).strip()
+
+    def _friendly_proxy_error(detail):
+        if 'default credentials' in detail or 'could not find default credentials' in detail:
+            return (
+                f'{binary} could not authenticate.\n\n'
+                'Run the following in a terminal, then retry:\n\n'
+                'gcloud auth application-default login\n\n'
+                'Note: this is separate from `gcloud auth login` — the proxy '
+                'uses Application Default Credentials (ADC).'
+            )
+        if 'NOT_AUTHORIZED' in detail or 'cloudsql.instances.connect' in detail or (
+            '403' in detail and 'forbidden' in detail.lower()
+        ):
+            return (
+                'Permission denied: your account does not have access to this Cloud SQL instance.\n\n'
+                'Ask a project owner to grant you the Cloud SQL Client role:\n\n'
+                'gcloud projects add-iam-policy-binding PROJECT \\\n'
+                '  --member="user:YOUR_EMAIL" \\\n'
+                '  --role="roles/cloudsql.client"'
+            )
+        return f'{binary} crashed.\n\n{detail}' if detail else f'{binary} crashed.'
 
     try:
         # Wait for the proxy to begin listening (up to 10 s)
@@ -160,13 +211,31 @@ def _cloud_proxy_tunnel(conn):
                     break
             except OSError:
                 if proc.poll() is not None:
-                    raise RuntimeError(f'{binary} exited unexpectedly during startup.')
+                    raise RuntimeError(_friendly_proxy_error(_get_stderr()))
                 time.sleep(0.2)
         else:
             proc.terminate()
-            raise RuntimeError(f'{binary} did not start listening within 10 seconds.')
-        yield '127.0.0.1', local_port
+            msg = f'{binary} did not start listening within 10 seconds.'
+            detail = _get_stderr()
+            if detail:
+                msg += f'\n\n{detail}'
+            raise RuntimeError(msg)
+        try:
+            yield '127.0.0.1', local_port
+        except Exception as exc:
+            # Terminate proxy now so the stderr pipe closes and we can read it.
+            proc.terminate()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=1)
+            detail = _get_stderr()
+            if detail:
+                raise RuntimeError(_friendly_proxy_error(detail)) from exc
+            raise
     finally:
+        # No-op if already terminated above; cleans up on the success path.
         proc.terminate()
         try:
             proc.wait(timeout=5)

--- a/src/tunnel.py
+++ b/src/tunnel.py
@@ -1,6 +1,9 @@
 import select
+import shutil
 import socket
+import subprocess
 import threading
+import time
 from contextlib import contextmanager
 
 
@@ -60,6 +63,25 @@ def apply_conn_settings(db, conn):
     db.commit()
 
 
+def _psycopg_kwargs(conn, host, port, password=None):
+    """Build psycopg.connect keyword arguments from a connection profile."""
+    kwargs = dict(
+        host=host,
+        port=port,
+        dbname=conn['database'],
+        user=conn['username'],
+        password=password if password is not None else conn.get('password', ''),
+        connect_timeout=10,
+    )
+    ssl_mode = conn.get('ssl_mode')
+    if ssl_mode and ssl_mode != 'prefer':
+        kwargs['sslmode'] = ssl_mode
+    ssl_root_cert = conn.get('ssl_root_cert')
+    if ssl_root_cert:
+        kwargs['sslrootcert'] = ssl_root_cert
+    return kwargs
+
+
 @contextmanager
 def open_db(conn, autocommit=False):
     """Open a psycopg connection via tunnel with session settings applied.
@@ -70,15 +92,20 @@ def open_db(conn, autocommit=False):
 
     Pass autocommit=True for DDL that must run outside a transaction block,
     e.g. CREATE/DROP INDEX CONCURRENTLY.
+
+    Handles cloud_auth_mode='iam': fetches a fresh gcloud access token and
+    uses it as the PostgreSQL password.
     """
     import psycopg
+
+    # Resolve password (IAM token or stored password)
+    password = conn.get('password', '')
+    if conn.get('cloud_auth_mode') == 'iam':
+        from gcp_discovery import get_iam_token
+        password = get_iam_token()
+
     with open_tunnel(conn) as (host, port), psycopg.connect(
-        host=host,
-        port=port,
-        dbname=conn['database'],
-        user=conn['username'],
-        password=conn['password'],
-        connect_timeout=10,
+        **_psycopg_kwargs(conn, host, port, password=password)
     ) as db:
         apply_conn_settings(db, conn)
         if autocommit:
@@ -87,12 +114,79 @@ def open_db(conn, autocommit=False):
 
 
 @contextmanager
+def _cloud_proxy_tunnel(conn):
+    """Launch cloud-sql-proxy or alloydb-auth-proxy and yield (host, local_port).
+
+    Selects the proxy binary based on cloud_provider:
+      - 'gcp-cloudsql'  → cloud-sql-proxy  <instance_id> --port <port>
+      - 'gcp-alloydb'   → alloydb-auth-proxy <instance_uri> --port <port>
+
+    Waits up to 10 s for the proxy to accept TCP connections, then yields.
+    Terminates the proxy subprocess on context exit.
+    """
+    provider = conn.get('cloud_provider', '')
+    instance_id = conn.get('cloud_instance_id', '')
+    if not instance_id:
+        raise RuntimeError('cloud_instance_id is required for cloud proxy connections.')
+
+    if provider == 'gcp-alloydb':
+        binary = 'alloydb-auth-proxy'
+    else:
+        binary = 'cloud-sql-proxy'
+
+    if not shutil.which(binary):
+        raise RuntimeError(
+            f'{binary} not found on $PATH. '
+            'Install it to connect to this instance.'
+        )
+
+    local_port = _free_port()
+    cmd = [binary, instance_id, '--port', str(local_port)]
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as e:
+        raise RuntimeError(f'Could not start {binary}: {e}')
+
+    try:
+        # Wait for the proxy to begin listening (up to 10 s)
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(('127.0.0.1', local_port), timeout=0.5):
+                    break
+            except OSError:
+                if proc.poll() is not None:
+                    raise RuntimeError(f'{binary} exited unexpectedly during startup.')
+                time.sleep(0.2)
+        else:
+            proc.terminate()
+            raise RuntimeError(f'{binary} did not start listening within 10 seconds.')
+        yield '127.0.0.1', local_port
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+@contextmanager
 def open_tunnel(conn):
     """
     Yields (host, port) to connect Postgres to.
-    Opens an SSH tunnel when conn['ssh_enabled'] is True,
-    otherwise passes the original host/port straight through.
+    - SSH tunnel when conn['ssh_enabled'] is True
+    - Cloud proxy when conn['cloud_proxy_enabled'] is True
+    - Direct otherwise
     """
+    if conn.get('cloud_proxy_enabled'):
+        with _cloud_proxy_tunnel(conn) as (host, port):
+            yield host, port
+        return
+
     if not conn.get('ssh_enabled'):
         yield conn['host'], conn['port']
         return

--- a/src/window.py
+++ b/src/window.py
@@ -348,6 +348,8 @@ class TuskWindow(Adw.ApplicationWindow):
         add_btn.connect('clicked', self._on_add_connection)
         add_menu = Gio.Menu()
         add_menu.append('Import from .pgpass…', 'win.import-pgpass')
+        add_menu.append('Import connections…', 'win.import-connections-json')
+        add_menu.append('Import from GCP…', 'win.import-from-gcp')
         add_btn.set_menu_model(add_menu)
         header.pack_end(add_btn)
 
@@ -439,6 +441,8 @@ class TuskWindow(Adw.ApplicationWindow):
         self._browser.connect('edit-connection-requested', self._on_edit_connection_from_browser)
         self._browser.connect('copy-to-clipboard', self._on_copy_to_clipboard)
         self._browser.connect('server-activity-requested', lambda _b, conn: self._on_server_activity(conn))
+        self._browser.connect('proxy-not-found', self._on_proxy_not_found)
+        self._browser.connect('connection-failed', lambda _b: self._set_active_conn(None))
         sidebar_paned.set_start_child(self._browser)
 
         self._file_explorer = FileExplorer()
@@ -519,8 +523,6 @@ class TuskWindow(Adw.ApplicationWindow):
         overflow_menu.append('Check all connections', 'win.check-all-health')
         overflow_menu.append('Export all to .pgpass…', 'win.export-pgpass-bulk')
         overflow_menu.append('Export connections…', 'win.export-connections-json')
-        overflow_menu.append('Import connections…', 'win.import-connections-json')
-        overflow_menu.append('Import from GCP…', 'win.import-from-gcp')
         overflow_menu.append('Clean up stale…', 'win.cleanup-stale')
         overflow_btn = Gtk.MenuButton()
         overflow_btn.set_icon_name('view-more-symbolic')
@@ -529,10 +531,15 @@ class TuskWindow(Adw.ApplicationWindow):
         overflow_btn.add_css_class('flat')
         mgr_toolbar.append(overflow_btn)
 
-        mgr_add_btn = Gtk.Button(label='Add Connection')
+        mgr_add_btn = Adw.SplitButton(label='Add Connection')
         mgr_add_btn.add_css_class('suggested-action')
         mgr_add_btn.add_css_class('pill')
         mgr_add_btn.connect('clicked', self._on_add_connection)
+        mgr_add_menu = Gio.Menu()
+        mgr_add_menu.append('Import from .pgpass…', 'win.import-pgpass')
+        mgr_add_menu.append('Import connections…', 'win.import-connections-json')
+        mgr_add_menu.append('Import from GCP…', 'win.import-from-gcp')
+        mgr_add_btn.set_menu_model(mgr_add_menu)
         mgr_toolbar.append(mgr_add_btn)
 
         mgr_box.append(mgr_toolbar)
@@ -1178,7 +1185,7 @@ class TuskWindow(Adw.ApplicationWindow):
             self._mgr_list.invalidate_sort()
 
         self._set_active_conn(conn)
-        self._browser.load(conn)
+        self._browser.load(conn, initial_connect=True)
 
     def _on_database_switched(self, _browser, conn, new_dbname):
         # Close all table and function tabs from the current database before switching
@@ -1196,7 +1203,7 @@ class TuskWindow(Adw.ApplicationWindow):
 
         new_conn = {**conn, 'database': new_dbname}
         self._set_active_conn(new_conn)
-        self._browser.load(new_conn)
+        self._browser.load(new_conn, initial_connect=True)
 
     def _on_role_attrs_loaded(self, _browser, conn, attrs):
         """Update the role badge on the matching connection row and dropdown."""
@@ -1291,7 +1298,7 @@ class TuskWindow(Adw.ApplicationWindow):
         # Switch active connection to postgres fallback and reload browser
         new_conn = {**conn, 'database': 'postgres'}
         self._set_active_conn(new_conn)
-        self._browser.load(new_conn)
+        self._browser.load(new_conn, initial_connect=True)
 
     def _on_disconnect(self, row):
         if self._active_conn_id == row._conn['id']:
@@ -1702,6 +1709,31 @@ class TuskWindow(Adw.ApplicationWindow):
         if skipped:
             msg += f' {skipped} skipped (already present).'
         self._show_toast(msg)
+
+    def _on_proxy_not_found(self, _browser, binary):
+        _INSTALL = {
+            'cloud-sql-proxy': (
+                'Cloud SQL Auth Proxy',
+                'https://cloud.google.com/sql/docs/postgres/sql-proxy#install',
+            ),
+            'alloydb-auth-proxy': (
+                'AlloyDB Auth Proxy',
+                'https://cloud.google.com/alloydb/docs/auth-proxy/connect#install-proxy',
+            ),
+        }
+        name, install_url = _INSTALL.get(binary, (binary, f'https://cloud.google.com/'))
+        dialog = Adw.AlertDialog(
+            heading=f'{name} Required',
+            body=(
+                f'This connection uses a private IP and requires {name} to create a '
+                f'secure tunnel. Install it and make sure it is on your $PATH.\n\n'
+                f'See the installation guide for the latest download:\n{install_url}'
+            ),
+        )
+        dialog.add_response('ok', 'OK')
+        dialog.set_default_response('ok')
+        dialog.set_close_response('ok')
+        dialog.present(self)
 
     def _on_import_from_gcp(self):
         existing_instance_ids = {

--- a/src/window.py
+++ b/src/window.py
@@ -14,6 +14,7 @@ from gi.repository import Gtk, Adw, Gio, GLib, GObject, Gdk, Pango
 import prefs
 from connections import ConnectionStore, KeyringUnavailableError
 from connection_dialog import ConnectionDialog
+from gcp_discovery_dialog import GcpDiscoveryDialog
 from style import MARGIN_XS, MARGIN_SM, MARGIN_MD
 from db_browser import DbBrowser
 from file_explorer import FileExplorer
@@ -101,6 +102,7 @@ class TuskWindow(Adw.ApplicationWindow):
         add('export-pgpass-bulk',         lambda *_: self._on_export_pgpass_bulk())
         add('export-connections-json',    lambda *_: self._on_export_connections_json())
         add('import-connections-json',    lambda *_: self._on_import_connections_json())
+        add('import-from-gcp',           lambda *_: self._on_import_from_gcp())
         add('cleanup-stale',              lambda *_: self._on_cleanup_stale())
         for _key in ('name', 'last-connected', 'manual'):
             _a = Gio.SimpleAction.new(f'conn-sort-{_key}', None)
@@ -518,6 +520,7 @@ class TuskWindow(Adw.ApplicationWindow):
         overflow_menu.append('Export all to .pgpass…', 'win.export-pgpass-bulk')
         overflow_menu.append('Export connections…', 'win.export-connections-json')
         overflow_menu.append('Import connections…', 'win.import-connections-json')
+        overflow_menu.append('Import from GCP…', 'win.import-from-gcp')
         overflow_menu.append('Clean up stale…', 'win.cleanup-stale')
         overflow_btn = Gtk.MenuButton()
         overflow_btn.set_icon_name('view-more-symbolic')
@@ -1698,6 +1701,34 @@ class TuskWindow(Adw.ApplicationWindow):
         msg = f'{added} connection{"s" if added != 1 else ""} imported.'
         if skipped:
             msg += f' {skipped} skipped (already present).'
+        self._show_toast(msg)
+
+    def _on_import_from_gcp(self):
+        existing_instance_ids = {
+            c.get('cloud_instance_id')
+            for c in self._store.list()
+            if c.get('cloud_instance_id')
+        }
+        dlg = GcpDiscoveryDialog(existing_instance_ids=existing_instance_ids)
+        dlg.connect('import-confirmed', self._on_gcp_import_confirmed)
+        dlg.present(self)
+
+    def _on_gcp_import_confirmed(self, _dlg, conns):
+        # Build the tags registry for GCP tags that may not exist yet
+        tags_registry = {}
+        for conn in conns:
+            for tag in conn.get('tags', []):
+                tags_registry.setdefault(tag, {'color': '#4285F4', 'warn_on_connect': False})
+        added, skipped = self._store.bulk_import(conns, tags_registry)
+        existing_ids = set(self._conn_mgr_rows.keys())
+        tags_reg = self._store.get_tags_registry()
+        for conn in self._store.list():
+            if conn['id'] not in existing_ids:
+                self._add_connection_row(conn, tags_registry=tags_reg)
+        self._refresh_tag_strip()
+        msg = f'{added} connection{"s" if added != 1 else ""} imported from GCP.'
+        if skipped:
+            msg += f' {skipped} skipped.'
         self._show_toast(msg)
 
     def _on_cleanup_stale(self):


### PR DESCRIPTION
## Summary
- Adds "Import from GCP…" to the Add Connection split button (sidebar and manager), which discovers Cloud SQL and AlloyDB PostgreSQL instances via the gcloud CLI
- Handles private-IP instances via cloud-sql-proxy / alloydb-auth-proxy, IAM database authentication, SSL cert fetching, and friendly error messages for missing credentials or permissions
- Adds two new files: gcp_discovery.py (backend, no GTK) and gcp_discovery_dialog.py (Adw.Dialog with grouped results, proxy install banner)

## Issues
Closes #280

## Test plan
- [ ] Click Add Connection → Import from GCP… with gcloud authenticated and a project active — instances appear grouped by service and region
- [ ] Import a public-IP Cloud SQL instance — connects with SSL cert applied
- [ ] Import a private-IP instance — error shown if cloud-sql-proxy not on PATH, with link to install docs
- [ ] Import a private-IP instance with cloud-sql-proxy installed — proxy launches, connection succeeds
- [ ] IAM auth instance — gcloud access token used as password
- [ ] Connection failure on initial connect clears the "connected" pill in sidebar
- [ ] Reloading the schema tree (pin/unpin, DDL) on a broken connection shows the error bar but does NOT clear the active connection
- [ ] Error text in sidebar is selectable/copyable

🤖 Generated with [Claude Code](https://claude.com/claude-code)