### PR TITLE
feat: tag rename and friendly color picker in Manage Tags

### DIFF
--- a/src/connections.py
+++ b/src/connections.py
@@ -119,6 +119,21 @@ class ConnectionStore:
         self._tags_registry.pop(name, None)
         self._save()
 
+    def rename_tag(self, old_name, new_name):
+        """Rename a tag and cascade the change to all connections in one write."""
+        if old_name not in self._tags_registry or old_name == new_name:
+            return
+        meta = self._tags_registry.pop(old_name)
+        self._tags_registry[new_name] = meta
+        for i, c in enumerate(self._connections):
+            tags = c.get('tags', [])
+            if old_name in tags:
+                self._connections[i] = {
+                    **c,
+                    'tags': [new_name if t == old_name else t for t in tags],
+                }
+        self._save()
+
     def list(self):
         return list(self._connections)
 

--- a/src/connections.py
+++ b/src/connections.py
@@ -127,6 +127,8 @@ class ConnectionStore:
         """
         if old_name not in self._tags_registry or old_name == new_name:
             return
+        if new_name in self._tags_registry:
+            return
         meta = self._tags_registry.pop(old_name)
         self._tags_registry[new_name] = meta
         for i, c in enumerate(self._connections):

--- a/src/connections.py
+++ b/src/connections.py
@@ -119,8 +119,12 @@ class ConnectionStore:
         self._tags_registry.pop(name, None)
         self._save()
 
-    def rename_tag(self, old_name, new_name):
-        """Rename a tag and cascade the change to all connections in one write."""
+    def rename_tag(self, old_name, new_name, *, _defer_save=False):
+        """Rename a tag and cascade the change to all connections.
+
+        Pass _defer_save=True when a subsequent store call (e.g. set_tag) will
+        write the file, to avoid a redundant intermediate save.
+        """
         if old_name not in self._tags_registry or old_name == new_name:
             return
         meta = self._tags_registry.pop(old_name)
@@ -132,7 +136,8 @@ class ConnectionStore:
                     **c,
                     'tags': [new_name if t == old_name else t for t in tags],
                 }
-        self._save()
+        if not _defer_save:
+            self._save()
 
     def list(self):
         return list(self._connections)

--- a/src/tags_dialog.py
+++ b/src/tags_dialog.py
@@ -33,6 +33,21 @@ _PALETTE_CSS = """
 }
 """
 
+_css_provider = None
+
+
+def _ensure_css():
+    global _css_provider
+    if _css_provider is not None:
+        return
+    _css_provider = Gtk.CssProvider()
+    _css_provider.load_from_string(_PALETTE_CSS)
+    Gtk.StyleContext.add_provider_for_display(
+        Gdk.Display.get_default(),
+        _css_provider,
+        Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+    )
+
 
 class TagsDialog(Adw.Dialog):
     __gsignals__ = {
@@ -42,13 +57,7 @@ class TagsDialog(Adw.Dialog):
     def __init__(self, store):
         super().__init__(title='Manage Tags', content_width=480, content_height=560)
         self._store = store
-        self._css_provider = Gtk.CssProvider()
-        self._css_provider.load_from_string(_PALETTE_CSS)
-        Gtk.StyleContext.add_provider_for_display(
-            Gdk.Display.get_default(),
-            self._css_provider,
-            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
-        )
+        _ensure_css()
         self._build_ui()
         self._load_tags()
 
@@ -158,11 +167,6 @@ class TagsDialog(Adw.Dialog):
             expander._palette_btns[color] = btn
             flow.append(btn)
 
-        custom_btn = Gtk.Button(label='Custom…')
-        custom_btn.add_css_class('flat')
-        custom_btn.set_halign(Gtk.Align.START)
-        custom_btn.connect('clicked', self._on_custom_color, expander)
-
         inner = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
         inner.set_margin_top(8)
         inner.set_margin_bottom(8)
@@ -170,7 +174,6 @@ class TagsDialog(Adw.Dialog):
         inner.set_margin_end(12)
         inner.append(caption)
         inner.append(flow)
-        inner.append(custom_btn)
 
         row = Gtk.ListBoxRow()
         row.set_selectable(False)
@@ -205,33 +208,6 @@ class TagsDialog(Adw.Dialog):
         expander._selected_color = color
         self._apply_swatch_markup(expander._swatch, color)
 
-    def _on_custom_color(self, _btn, expander):
-        dialog = Gtk.ColorDialog()
-        dialog.set_with_alpha(False)
-        # Parse current hex to RGBA
-        color = expander._selected_color
-        rgba = Gdk.RGBA()
-        rgba.parse(color if _COLOR_RE.match(color or '') else _DEFAULT_COLOR)
-        dialog.choose_rgba(self, rgba, None, self._on_custom_color_done, expander)
-
-    def _on_custom_color_done(self, dialog, result, expander):
-        try:
-            rgba = dialog.choose_rgba_finish(result)
-        except Exception:
-            return
-        if rgba is None:
-            return
-        # Convert RGBA to #rrggbb
-        r = int(rgba.red * 255)
-        g = int(rgba.green * 255)
-        b = int(rgba.blue * 255)
-        color = f'#{r:02x}{g:02x}{b:02x}'
-        # Deselect all preset swatches (custom color isn't in palette)
-        for btn in expander._palette_btns.values():
-            btn.remove_css_class('swatch-selected')
-        expander._selected_color = color
-        self._apply_swatch_markup(expander._swatch, color)
-
     def _on_save_tag(self, _row, expander):
         old_name = expander._tag_name
         new_name = expander._name_row.get_text().strip()
@@ -250,7 +226,7 @@ class TagsDialog(Adw.Dialog):
         color = expander._selected_color
 
         if new_name != old_name:
-            self._store.rename_tag(old_name, new_name)
+            self._store.rename_tag(old_name, new_name, _defer_save=True)
 
         self._store.set_tag(new_name, color, warn)
         expander.set_expanded(False)
@@ -339,6 +315,21 @@ class TagsDialog(Adw.Dialog):
         entries_box.append(palette_row)
 
         dialog.set_extra_child(entries_box)
+
+        # Disable Add until the user types a non-empty, non-duplicate name
+        dialog.set_response_enabled('add', False)
+
+        def on_name_changed(_entry, _param):
+            name = name_entry.get_text().strip()
+            duplicate = name in self._store.get_tags_registry()
+            dialog.set_response_enabled('add', bool(name) and not duplicate)
+            if name and duplicate:
+                name_entry.add_css_class('error')
+            else:
+                name_entry.remove_css_class('error')
+
+        name_entry.connect('notify::text', on_name_changed)
+
         dialog.connect('response', self._on_add_confirmed, name_entry, selected)
         dialog.present(self)
 
@@ -346,10 +337,9 @@ class TagsDialog(Adw.Dialog):
         if response != 'add':
             return
         name = name_entry.get_text().strip()
-        if not name:
-            return
+        if not name or name in self._store.get_tags_registry():
+            return  # guarded by button state, but defensive
         color = selected[0] if _COLOR_RE.match(selected[0] or '') else _DEFAULT_COLOR
-        if name not in self._store.get_tags_registry():
-            self._store.set_tag(name, color, False)
+        self._store.set_tag(name, color, False)
         self._load_tags()
         self.emit('tags-changed')

--- a/src/tags_dialog.py
+++ b/src/tags_dialog.py
@@ -5,10 +5,33 @@ import gi
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 
-from gi.repository import Gtk, Adw, GObject, GLib
+from gi.repository import Gtk, Adw, GObject, GLib, Gdk
 
 _COLOR_RE = re.compile(r'^#[0-9a-fA-F]{6}$')
 _DEFAULT_COLOR = '#aaaaaa'
+
+_PRESET_COLORS = [
+    '#e74c3c',  # Red
+    '#e67e22',  # Orange
+    '#f1c40f',  # Yellow
+    '#2ecc71',  # Green
+    '#1abc9c',  # Teal
+    '#3498db',  # Blue
+    '#9b59b6',  # Purple
+    '#e91e63',  # Pink
+    '#607d8b',  # Blue-grey
+    '#795548',  # Brown
+    '#aaaaaa',  # Grey
+    '#4285f4',  # GCP Blue
+]
+
+_PALETTE_CSS = """
+.swatch-selected {
+    outline: 3px solid @accent_bg_color;
+    outline-offset: 1px;
+    border-radius: 50%;
+}
+"""
 
 
 class TagsDialog(Adw.Dialog):
@@ -19,6 +42,13 @@ class TagsDialog(Adw.Dialog):
     def __init__(self, store):
         super().__init__(title='Manage Tags', content_width=480, content_height=560)
         self._store = store
+        self._css_provider = Gtk.CssProvider()
+        self._css_provider.load_from_string(_PALETTE_CSS)
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
+            self._css_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+        )
         self._build_ui()
         self._load_tags()
 
@@ -63,22 +93,28 @@ class TagsDialog(Adw.Dialog):
             self._list_box.append(self._build_tag_row(name, meta))
 
     def _build_tag_row(self, name, meta):
+        color = meta.get('color', _DEFAULT_COLOR)
         expander = Adw.ExpanderRow(title=name)
         expander._tag_name = name
+        expander._selected_color = color
+        expander._palette_btns = {}
 
         # Colour swatch prefix
         swatch = Gtk.Label()
         swatch.set_valign(Gtk.Align.CENTER)
-        self._apply_swatch_color(swatch, meta.get('color', _DEFAULT_COLOR))
+        self._apply_swatch_markup(swatch, color)
         expander.add_prefix(swatch)
         expander._swatch = swatch
 
-        # Color entry
-        color_row = Adw.EntryRow(title='Color (hex)')
-        color_row.set_text(meta.get('color', _DEFAULT_COLOR))
-        color_row.connect('notify::text', self._on_color_changed, expander)
-        expander.add_row(color_row)
-        expander._color_row = color_row
+        # Name entry
+        name_row = Adw.EntryRow(title='Name')
+        name_row.set_text(name)
+        expander.add_row(name_row)
+        expander._name_row = name_row
+
+        # Colour palette row
+        palette_list_row = self._build_palette_list_row(expander, color)
+        expander.add_row(palette_list_row)
 
         # Warn on connect switch
         warn_row = Adw.SwitchRow(
@@ -86,7 +122,6 @@ class TagsDialog(Adw.Dialog):
             subtitle='Show a confirmation prompt before connecting',
         )
         warn_row.set_active(meta.get('warn_on_connect', False))
-        warn_row.connect('notify::active', self._on_warn_changed, expander)
         expander.add_row(warn_row)
         expander._warn_row = warn_row
 
@@ -103,28 +138,123 @@ class TagsDialog(Adw.Dialog):
 
         return expander
 
+    def _build_palette_list_row(self, expander, selected_color):
+        """Build a ListBoxRow containing the colour swatch grid + Custom button."""
+        caption = Gtk.Label(label='Color', xalign=0)
+        caption.add_css_class('caption')
+        caption.add_css_class('dim-label')
+
+        flow = Gtk.FlowBox()
+        flow.set_selection_mode(Gtk.SelectionMode.NONE)
+        flow.set_max_children_per_line(6)
+        flow.set_min_children_per_line(6)
+        flow.set_homogeneous(True)
+        flow.set_column_spacing(4)
+        flow.set_row_spacing(4)
+
+        for color in _PRESET_COLORS:
+            btn = self._build_swatch_btn(color, color == selected_color)
+            btn.connect('clicked', self._on_palette_clicked, color, expander)
+            expander._palette_btns[color] = btn
+            flow.append(btn)
+
+        custom_btn = Gtk.Button(label='Custom…')
+        custom_btn.add_css_class('flat')
+        custom_btn.set_halign(Gtk.Align.START)
+        custom_btn.connect('clicked', self._on_custom_color, expander)
+
+        inner = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        inner.set_margin_top(8)
+        inner.set_margin_bottom(8)
+        inner.set_margin_start(12)
+        inner.set_margin_end(12)
+        inner.append(caption)
+        inner.append(flow)
+        inner.append(custom_btn)
+
+        row = Gtk.ListBoxRow()
+        row.set_selectable(False)
+        row.set_activatable(False)
+        row.set_child(inner)
+        return row
+
     @staticmethod
-    def _apply_swatch_color(swatch, color):
+    def _build_swatch_btn(color, selected):
+        btn = Gtk.Button()
+        btn.add_css_class('flat')
+        btn.add_css_class('circular')
+        lbl = Gtk.Label()
+        lbl.set_markup(f'<span foreground="{color}" size="xx-large">⬤</span>')
+        btn.set_child(lbl)
+        if selected:
+            btn.add_css_class('swatch-selected')
+        return btn
+
+    @staticmethod
+    def _apply_swatch_markup(label, color):
         safe = color if _COLOR_RE.match(color or '') else _DEFAULT_COLOR
-        swatch.set_markup(f'<span foreground="{safe}">⬤</span>')
+        label.set_markup(f'<span foreground="{safe}">⬤</span>')
 
-    def _on_color_changed(self, row, _param, expander):
-        color = row.get_text().strip()
-        self._apply_swatch_color(expander._swatch, color)
+    def _on_palette_clicked(self, _btn, color, expander):
+        # Deselect all, select clicked
+        for c, b in expander._palette_btns.items():
+            if c == color:
+                b.add_css_class('swatch-selected')
+            else:
+                b.remove_css_class('swatch-selected')
+        expander._selected_color = color
+        self._apply_swatch_markup(expander._swatch, color)
 
-    def _on_warn_changed(self, _row, _param, _expander):
-        pass  # handled on Save
+    def _on_custom_color(self, _btn, expander):
+        dialog = Gtk.ColorDialog()
+        dialog.set_with_alpha(False)
+        # Parse current hex to RGBA
+        color = expander._selected_color
+        rgba = Gdk.RGBA()
+        rgba.parse(color if _COLOR_RE.match(color or '') else _DEFAULT_COLOR)
+        dialog.choose_rgba(self, rgba, None, self._on_custom_color_done, expander)
+
+    def _on_custom_color_done(self, dialog, result, expander):
+        try:
+            rgba = dialog.choose_rgba_finish(result)
+        except Exception:
+            return
+        if rgba is None:
+            return
+        # Convert RGBA to #rrggbb
+        r = int(rgba.red * 255)
+        g = int(rgba.green * 255)
+        b = int(rgba.blue * 255)
+        color = f'#{r:02x}{g:02x}{b:02x}'
+        # Deselect all preset swatches (custom color isn't in palette)
+        for btn in expander._palette_btns.values():
+            btn.remove_css_class('swatch-selected')
+        expander._selected_color = color
+        self._apply_swatch_markup(expander._swatch, color)
 
     def _on_save_tag(self, _row, expander):
-        name = expander._tag_name
-        color = expander._color_row.get_text().strip()
-        if not _COLOR_RE.match(color):
-            expander._color_row.add_css_class('error')
+        old_name = expander._tag_name
+        new_name = expander._name_row.get_text().strip()
+
+        if not new_name:
+            expander._name_row.add_css_class('error')
             return
-        expander._color_row.remove_css_class('error')
+        expander._name_row.remove_css_class('error')
+
+        # Duplicate name check (allow same name)
+        if new_name != old_name and new_name in self._store.get_tags_registry():
+            expander._name_row.add_css_class('error')
+            return
+
         warn = expander._warn_row.get_active()
-        self._store.set_tag(name, color, warn)
+        color = expander._selected_color
+
+        if new_name != old_name:
+            self._store.rename_tag(old_name, new_name)
+
+        self._store.set_tag(new_name, color, warn)
         expander.set_expanded(False)
+        self._load_tags()
         self.emit('tags-changed')
 
     def _on_delete_tag(self, _row, expander):
@@ -144,13 +274,12 @@ class TagsDialog(Adw.Dialog):
     def _on_delete_confirmed(self, _dialog, response, name):
         if response != 'delete':
             return
-        # Remove from registry and all connections (single save)
         self._store.remove_tag(name)
         self._store.remove_tag_from_connections(name)
         self._load_tags()
         self.emit('tags-changed')
 
-    def _on_add_tag(self, _row):
+    def _on_add_tag(self, _btn):
         dialog = Adw.AlertDialog(heading='New Tag')
         dialog.add_response('cancel', 'Cancel')
         dialog.add_response('add', 'Add')
@@ -158,29 +287,68 @@ class TagsDialog(Adw.Dialog):
         dialog.set_default_response('add')
         dialog.set_close_response('cancel')
 
-        entry = Adw.EntryRow(title='Tag name')
-        color_entry = Adw.EntryRow(title='Color (hex)')
-        color_entry.set_text(_DEFAULT_COLOR)
+        name_entry = Adw.EntryRow(title='Tag name')
 
-        box = Gtk.ListBox()
-        box.add_css_class('boxed-list')
-        box.set_selection_mode(Gtk.SelectionMode.NONE)
-        box.append(entry)
-        box.append(color_entry)
-        dialog.set_extra_child(box)
+        # Compact palette for add dialog
+        selected = [_DEFAULT_COLOR]  # mutable container so lambda can mutate
+        palette_btns = {}
 
-        dialog.connect('response', self._on_add_confirmed, entry, color_entry)
+        flow = Gtk.FlowBox()
+        flow.set_selection_mode(Gtk.SelectionMode.NONE)
+        flow.set_max_children_per_line(6)
+        flow.set_min_children_per_line(6)
+        flow.set_homogeneous(True)
+        flow.set_column_spacing(4)
+        flow.set_row_spacing(4)
+
+        def on_swatch_clicked(_btn, color):
+            for c, b in palette_btns.items():
+                if c == color:
+                    b.add_css_class('swatch-selected')
+                else:
+                    b.remove_css_class('swatch-selected')
+            selected[0] = color
+
+        for color in _PRESET_COLORS:
+            btn = self._build_swatch_btn(color, color == _DEFAULT_COLOR)
+            btn.connect('clicked', on_swatch_clicked, color)
+            palette_btns[color] = btn
+            flow.append(btn)
+
+        caption = Gtk.Label(label='Color', xalign=0)
+        caption.add_css_class('caption')
+        caption.add_css_class('dim-label')
+
+        palette_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        palette_box.set_margin_top(8)
+        palette_box.set_margin_bottom(4)
+        palette_box.set_margin_start(12)
+        palette_box.set_margin_end(12)
+        palette_box.append(caption)
+        palette_box.append(flow)
+
+        entries_box = Gtk.ListBox()
+        entries_box.add_css_class('boxed-list')
+        entries_box.set_selection_mode(Gtk.SelectionMode.NONE)
+        entries_box.append(name_entry)
+
+        palette_row = Gtk.ListBoxRow()
+        palette_row.set_selectable(False)
+        palette_row.set_activatable(False)
+        palette_row.set_child(palette_box)
+        entries_box.append(palette_row)
+
+        dialog.set_extra_child(entries_box)
+        dialog.connect('response', self._on_add_confirmed, name_entry, selected)
         dialog.present(self)
 
-    def _on_add_confirmed(self, _dialog, response, entry, color_entry):
+    def _on_add_confirmed(self, _dialog, response, name_entry, selected):
         if response != 'add':
             return
-        name = entry.get_text().strip()
-        color = color_entry.get_text().strip()
+        name = name_entry.get_text().strip()
         if not name:
             return
-        if not _COLOR_RE.match(color):
-            color = _DEFAULT_COLOR
+        color = selected[0] if _COLOR_RE.match(selected[0] or '') else _DEFAULT_COLOR
         if name not in self._store.get_tags_registry():
             self._store.set_tag(name, color, False)
         self._load_tags()


### PR DESCRIPTION
## Summary
- Tags can now be renamed in-place; the new name cascades atomically to all connections that reference the old name in a single file write
- Hex color EntryRow replaced with a 12-color preset swatch palette (flat circular buttons with an outline ring on the selected color)
- New-tag dialog Add button is disabled until a valid non-duplicate name is typed; duplicate names show an inline error indicator

## Issues
Closes #300

## Test plan
- [ ] Open Manage Tags — existing tags show Name entry + color palette
- [ ] Edit a tag name and save — all connections using the old name update
- [ ] Try saving an empty or duplicate name — inline error shown, save blocked
- [ ] Pick a different swatch color and save — color updates correctly
- [ ] Add Tag dialog — Add button disabled until non-empty unique name is typed
- [ ] Duplicate name in Add dialog shows error class on the entry row
- [ ] Warn-on-connect and Delete still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)