### PR TITLE
feat: multi-project GCP database discovery with project picker

### DIFF
--- a/src/gcp_discovery.py
+++ b/src/gcp_discovery.py
@@ -104,6 +104,21 @@ def get_active_project():
     return val if val and val != '(unset)' else None
 
 
+def list_projects():
+    """Return accessible GCP projects sorted by display name.
+
+    Each dict: {id: str, name: str}
+    Raises RuntimeError on failure.
+    """
+    projects = _gcloud(
+        'projects', 'list',
+        '--filter=lifecycleState:ACTIVE',
+        '--sort-by=name',
+    )
+    return [{'id': p['projectId'], 'name': p.get('name', p['projectId'])}
+            for p in (projects if isinstance(projects, list) else [])]
+
+
 def get_active_account():
     """Return the active gcloud account email, or None if not authenticated."""
     try:
@@ -207,6 +222,7 @@ def build_cloud_sql_conn(instance, project, fetch_cert=True):
         '_gcp_service': 'Cloud SQL',
         '_gcp_version': db_version,
         '_gcp_region': region,
+        '_gcp_project': project,
     }
     return conn
 
@@ -302,6 +318,7 @@ def build_alloydb_conn(cluster, instance, project, fetch_cert=True):
         '_gcp_service': 'AlloyDB',
         '_gcp_version': 'AlloyDB',
         '_gcp_region': region,
+        '_gcp_project': project,
     }
     return conn
 

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -271,7 +271,9 @@ class GcpDiscoveryDialog(Adw.Dialog):
         text = self._project_search.get_text().lower()
         if not text:
             return True
-        return text in row.get_title().lower() or text in row.get_subtitle().lower()
+        title = (row.get_title() or '').lower()
+        subtitle = (row.get_subtitle() or '').lower()
+        return text in title or text in subtitle
 
     def _on_project_check_toggled(self, check):
         if check.get_active():
@@ -424,7 +426,11 @@ class GcpDiscoveryDialog(Adw.Dialog):
             error_label.set_margin_end(12)
             error_label.set_margin_top(8)
             error_label.set_margin_bottom(8)
-            expander.add_row(error_label)
+            error_row = Gtk.ListBoxRow()
+            error_row.set_selectable(False)
+            error_row.set_activatable(False)
+            error_row.set_child(error_label)
+            expander.add_row(error_row)
             self._results_list.append(expander)
 
         # Show proxy banner if any instances need a proxy binary that isn't installed

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -397,9 +397,26 @@ class GcpDiscoveryDialog(Adw.Dialog):
         summary = f'{total} instance{"s" if total != 1 else ""} found.'
         if already_count:
             summary += f' {already_count} already imported.'
-        if errors:
-            summary += f' (Errors: {"; ".join(errors)})'
         self._summary_label.set_text(summary)
+
+        if errors:
+            n = len(errors)
+            expander = Adw.ExpanderRow(
+                title=f'{n} discovery warning{"s" if n != 1 else ""}',
+                subtitle='Some services could not be queried — click to expand',
+            )
+            expander.set_icon_name('dialog-warning-symbolic')
+            error_label = Gtk.Label(label='\n\n'.join(errors))
+            error_label.set_wrap(True)
+            error_label.set_xalign(0)
+            error_label.add_css_class('dim-label')
+            error_label.set_selectable(True)
+            error_label.set_margin_start(12)
+            error_label.set_margin_end(12)
+            error_label.set_margin_top(8)
+            error_label.set_margin_bottom(8)
+            expander.add_row(error_label)
+            self._results_list.append(expander)
 
         # Show proxy banner if any instances need a proxy binary that isn't installed
         _PROXY_BINARY = {

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -95,7 +95,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
 
         self._project_list_scroll = Gtk.ScrolledWindow()
         self._project_list_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        self._project_list_scroll.set_max_content_height(220)
+        self._project_list_scroll.set_max_content_height(360)
         self._project_list_scroll.set_propagate_natural_height(True)
         self._project_list_scroll.set_child(self._project_list_box)
 
@@ -204,6 +204,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
                 'Download: https://cloud.google.com/sdk/docs/install')
             return
 
+        GLib.idle_add(self._loading_label_widget.set_text, 'Checking authentication…')
         account = gcp_discovery.get_active_account()
         if not account:
             GLib.idle_add(self._show_error,
@@ -211,6 +212,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
                 'No active gcloud credentials found.\n\nRun `gcloud auth login` in a terminal and try again.')
             return
 
+        GLib.idle_add(self._loading_label_widget.set_text, 'Fetching project list…')
         active_project = gcp_discovery.get_active_project()
         try:
             projects = gcp_discovery.list_projects()

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -23,7 +23,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
     }
 
     def __init__(self, existing_instance_ids=None):
-        super().__init__(title='Import from GCP', content_width=540, content_height=580)
+        super().__init__(title='Import from GCP', content_width=540)
         self._existing_ids = set(existing_instance_ids or [])
         self._conns = []   # discovered connection dicts with internal _gcp_* keys
         self._checks = {}  # idx → (Gtk.CheckButton, conn_dict)
@@ -87,6 +87,11 @@ class GcpDiscoveryDialog(Adw.Dialog):
         self._project_list_box = Gtk.ListBox()
         self._project_list_box.add_css_class('boxed-list')
         self._project_list_box.set_selection_mode(Gtk.SelectionMode.NONE)
+        self._project_list_box.set_filter_func(self._project_filter_func)
+
+        self._project_search = Gtk.SearchEntry(placeholder_text='Filter projects…')
+        self._project_search.connect('search-changed',
+                                     lambda _: self._project_list_box.invalidate_filter())
 
         self._project_list_scroll = Gtk.ScrolledWindow()
         self._project_list_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
@@ -131,6 +136,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
         box.set_margin_end(20)
         box.set_vexpand(True)
         box.append(list_group)
+        box.append(self._project_search)
         box.append(self._project_list_scroll)
         box.append(self._project_fetch_error)
         box.append(manual_group)
@@ -228,10 +234,12 @@ class GcpDiscoveryDialog(Adw.Dialog):
             self._project_list_box.remove(row)
 
         if not projects:
+            self._project_search.set_visible(False)
             self._project_list_scroll.set_visible(False)
             self._project_fetch_error.set_visible(True)
             return
 
+        self._project_search.set_visible(True)
         self._project_list_scroll.set_visible(True)
         self._project_fetch_error.set_visible(False)
 
@@ -252,6 +260,15 @@ class GcpDiscoveryDialog(Adw.Dialog):
         self._project_list_box.append(row)
         self._project_rows.append((check, project_id))
 
+    def _project_filter_func(self, row):
+        text = self._project_search.get_text().lower()
+        if not text:
+            return True
+        child = row.get_child()
+        title = (child.get_title() if hasattr(child, 'get_title') else '').lower()
+        subtitle = (child.get_subtitle() if hasattr(child, 'get_subtitle') else '').lower()
+        return text in title or text in subtitle
+
     def _on_manual_add(self, _widget):
         project_id = self._manual_entry.get_text().strip()
         if not project_id:
@@ -261,6 +278,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
         if project_id in existing_ids:
             self._manual_entry.set_text('')
             return
+        self._project_search.set_visible(True)
         self._project_list_scroll.set_visible(True)
         self._add_project_row(project_id, checked=True)
         self._manual_entry.set_text('')

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -184,9 +184,17 @@ class GcpDiscoveryDialog(Adw.Dialog):
         return scroll
 
     def _build_error_page(self):
+        self._error_back_btn = Gtk.Button(label='Choose Different Projects')
+        self._error_back_btn.add_css_class('pill')
+        self._error_back_btn.set_halign(Gtk.Align.CENTER)
+        self._error_back_btn.set_visible(False)
+        self._error_back_btn.connect('clicked',
+                                     lambda _: self._stack.set_visible_child_name('project'))
+
         self._error_status = Adw.StatusPage(
             icon_name='dialog-error-symbolic',
             title='Discovery Failed',
+            child=self._error_back_btn,
         )
         return self._error_status
 
@@ -336,7 +344,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
             msg = 'No PostgreSQL instances found in the selected project(s).'
             if errors:
                 msg += '\n\nErrors:\n' + '\n'.join(errors)
-            self._show_error('No instances found', msg)
+            self._show_error('No instances found', msg, show_back=True)
             return
 
         # Determine whether results span multiple projects
@@ -442,9 +450,10 @@ class GcpDiscoveryDialog(Adw.Dialog):
 
         self._stack.set_visible_child_name('results')
 
-    def _show_error(self, title, description):
+    def _show_error(self, title, description, show_back=False):
         self._error_status.set_title(title)
         self._error_status.set_description(description)
+        self._error_back_btn.set_visible(show_back)
         self._stack.set_visible_child_name('error')
 
     def _on_proxy_banner_clicked(self, _banner):

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -27,7 +27,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
         self._existing_ids = set(existing_instance_ids or [])
         self._conns = []   # discovered connection dicts with internal _gcp_* keys
         self._checks = {}  # idx → (Gtk.CheckButton, conn_dict)
-        self._project = None
+        self._project_rows = []  # list of (check_button, project_id)
         self._missing_proxy_binaries = set()
         self._build_ui()
 
@@ -83,12 +83,40 @@ class GcpDiscoveryDialog(Adw.Dialog):
         return self._build_loading_page_with_label(label)
 
     def _build_project_page(self):
-        group = Adw.PreferencesGroup(
-            title='GCP Project',
-            description='No active project found. Enter the GCP project ID to discover databases in.',
+        # ── Project list (checkbox rows) ──────────────────────────────────────
+        self._project_list_box = Gtk.ListBox()
+        self._project_list_box.add_css_class('boxed-list')
+        self._project_list_box.set_selection_mode(Gtk.SelectionMode.NONE)
+
+        self._project_list_scroll = Gtk.ScrolledWindow()
+        self._project_list_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self._project_list_scroll.set_max_content_height(220)
+        self._project_list_scroll.set_propagate_natural_height(True)
+        self._project_list_scroll.set_child(self._project_list_box)
+
+        self._project_fetch_error = Gtk.Label(label='Could not fetch project list')
+        self._project_fetch_error.add_css_class('dim-label')
+        self._project_fetch_error.set_halign(Gtk.Align.START)
+        self._project_fetch_error.set_visible(False)
+
+        list_group = Adw.PreferencesGroup(
+            title='GCP Projects',
+            description='Select one or more projects to discover databases in.',
         )
-        self._project_entry = Adw.EntryRow(title='Project ID')
-        group.add(self._project_entry)
+
+        # ── Manual add row ────────────────────────────────────────────────────
+        manual_group = Adw.PreferencesGroup()
+        self._manual_entry = Adw.EntryRow(title='Add project ID manually')
+        self._manual_entry.connect('entry-activated', self._on_manual_add)
+
+        add_btn = Gtk.Button()
+        add_btn.set_icon_name('list-add-symbolic')
+        add_btn.set_tooltip_text('Add project')
+        add_btn.add_css_class('flat')
+        add_btn.set_valign(Gtk.Align.CENTER)
+        add_btn.connect('clicked', self._on_manual_add)
+        self._manual_entry.add_suffix(add_btn)
+        manual_group.add(self._manual_entry)
 
         discover_btn = Gtk.Button(label='Discover Databases')
         discover_btn.add_css_class('suggested-action')
@@ -101,11 +129,18 @@ class GcpDiscoveryDialog(Adw.Dialog):
         box.set_margin_bottom(20)
         box.set_margin_start(20)
         box.set_margin_end(20)
-        box.set_valign(Gtk.Align.CENTER)
         box.set_vexpand(True)
-        box.append(group)
+        box.append(list_group)
+        box.append(self._project_list_scroll)
+        box.append(self._project_fetch_error)
+        box.append(manual_group)
         box.append(discover_btn)
-        return box
+
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_propagate_natural_height(True)
+        scroll.set_child(box)
+        return scroll
 
     def _build_results_page(self):
         self._summary_label = Gtk.Label()
@@ -170,51 +205,100 @@ class GcpDiscoveryDialog(Adw.Dialog):
                 'No active gcloud credentials found.\n\nRun `gcloud auth login` in a terminal and try again.')
             return
 
-        project = gcp_discovery.get_active_project()
-        GLib.idle_add(self._on_gcloud_ready, project)
+        active_project = gcp_discovery.get_active_project()
+        try:
+            projects = gcp_discovery.list_projects()
+        except Exception:
+            projects = []
+        GLib.idle_add(self._on_gcloud_checked, active_project, projects)
 
-    def _on_gcloud_ready(self, project):
-        if project:
-            self._project = project
-            self._start_discovery(project)
-        else:
-            self._stack.set_visible_child_name('project')
+    def _on_gcloud_checked(self, active_project, projects):
+        self._populate_project_list(projects, active_project)
+        self._stack.set_visible_child_name('project')
+
+    def _populate_project_list(self, projects, active_project):
+        """Fill the project ListBox with checkbox rows. Pre-check active_project if found."""
+        self._project_rows = []
+
+        # Clear any existing rows
+        while True:
+            row = self._project_list_box.get_first_child()
+            if row is None:
+                break
+            self._project_list_box.remove(row)
+
+        if not projects:
+            self._project_list_scroll.set_visible(False)
+            self._project_fetch_error.set_visible(True)
+            return
+
+        self._project_list_scroll.set_visible(True)
+        self._project_fetch_error.set_visible(False)
+
+        for p in projects:
+            self._add_project_row(p['id'], p['name'],
+                                  checked=(p['id'] == active_project))
+
+    def _add_project_row(self, project_id, label=None, checked=False):
+        """Append a checkbox row for project_id to the project ListBox."""
+        row = Adw.ActionRow(title=label or project_id)
+        if label and label != project_id:
+            row.set_subtitle(project_id)
+        check = Gtk.CheckButton()
+        check.set_active(checked)
+        check.set_valign(Gtk.Align.CENTER)
+        row.add_suffix(check)
+        row.set_activatable_widget(check)
+        self._project_list_box.append(row)
+        self._project_rows.append((check, project_id))
+
+    def _on_manual_add(self, _widget):
+        project_id = self._manual_entry.get_text().strip()
+        if not project_id:
+            return
+        # Avoid duplicates
+        existing_ids = {pid for _, pid in self._project_rows}
+        if project_id in existing_ids:
+            self._manual_entry.set_text('')
+            return
+        self._project_list_scroll.set_visible(True)
+        self._add_project_row(project_id, checked=True)
+        self._manual_entry.set_text('')
 
     def _on_project_confirm(self, _btn):
-        project = self._project_entry.get_text().strip()
-        if not project:
-            self._project_entry.add_css_class('error')
+        selected = [pid for check, pid in self._project_rows if check.get_active()]
+        if not selected:
             return
-        self._project_entry.remove_css_class('error')
-        self._project = project
-        self._start_discovery(project)
+        self._start_discovery(selected)
 
-    def _start_discovery(self, project):
-        self._loading_label_widget.set_text(f'Discovering databases in {project}…')
+    def _start_discovery(self, projects):
+        label = projects[0] if len(projects) == 1 else f'{len(projects)} projects'
+        self._loading_label_widget.set_text(f'Discovering databases in {label}…')
         self._stack.set_visible_child_name('loading')
-        threading.Thread(target=self._run_discovery, args=(project,), daemon=True).start()
+        threading.Thread(target=self._run_discovery, args=(projects,), daemon=True).start()
 
-    def _run_discovery(self, project):
+    def _run_discovery(self, projects):
         conns = []
         errors = []
 
-        # Cloud SQL
-        try:
-            instances = gcp_discovery.discover_cloud_sql(project)
-            for inst in instances:
-                conn = gcp_discovery.build_cloud_sql_conn(inst, project, fetch_cert=True)
-                conns.append(conn)
-        except RuntimeError as e:
-            errors.append(f'Cloud SQL: {e}')
+        for project in projects:
+            # Cloud SQL
+            try:
+                instances = gcp_discovery.discover_cloud_sql(project)
+                for inst in instances:
+                    conn = gcp_discovery.build_cloud_sql_conn(inst, project, fetch_cert=True)
+                    conns.append(conn)
+            except RuntimeError as e:
+                errors.append(f'{project} / Cloud SQL: {e}')
 
-        # AlloyDB
-        try:
-            pairs = gcp_discovery.discover_alloydb(project)
-            for cluster, inst in pairs:
-                conn = gcp_discovery.build_alloydb_conn(cluster, inst, project, fetch_cert=True)
-                conns.append(conn)
-        except RuntimeError as e:
-            errors.append(f'AlloyDB: {e}')
+            # AlloyDB
+            try:
+                pairs = gcp_discovery.discover_alloydb(project)
+                for cluster, inst in pairs:
+                    conn = gcp_discovery.build_alloydb_conn(cluster, inst, project, fetch_cert=True)
+                    conns.append(conn)
+            except RuntimeError as e:
+                errors.append(f'{project} / AlloyDB: {e}')
 
         GLib.idle_add(self._show_results, conns, errors)
 
@@ -232,24 +316,32 @@ class GcpDiscoveryDialog(Adw.Dialog):
             self._results_list.remove(row)
 
         if not conns:
-            msg = 'No PostgreSQL instances found in this project.'
+            msg = 'No PostgreSQL instances found in the selected project(s).'
             if errors:
                 msg += '\n\nErrors:\n' + '\n'.join(errors)
             self._show_error('No instances found', msg)
             return
 
-        # Group by service then region
-        groups = {}  # (service, region) → [conn]
+        # Determine whether results span multiple projects
+        projects_in_results = {conn.get('_gcp_project', '') for conn in conns}
+        multi_project = len(projects_in_results) > 1
+
+        # Group by project, service, region
+        groups = {}  # (project, service, region) → [conn]
         for conn in conns:
-            key = (conn.get('_gcp_service', ''), conn.get('_gcp_region', ''))
+            key = (conn.get('_gcp_project', ''),
+                   conn.get('_gcp_service', ''),
+                   conn.get('_gcp_region', ''))
             groups.setdefault(key, []).append(conn)
 
         idx = 0
-        for (service, region), group_conns in sorted(groups.items()):
+        for (project, service, region), group_conns in sorted(groups.items()):
             # Section header row
-            header_row = Adw.ActionRow(
-                title=f'{service} — {region}' if region else service,
-            )
+            if multi_project and project:
+                title = f'{project} / {service} — {region}' if region else f'{project} / {service}'
+            else:
+                title = f'{service} — {region}' if region else service
+            header_row = Adw.ActionRow(title=title)
             header_row.set_activatable(False)
             header_row.add_css_class('dim-label')
             self._results_list.append(header_row)
@@ -264,7 +356,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
                     subtitle_parts.append('IAM auth')
                 if already:
                     subtitle_parts.append('Already imported')
-                row.set_subtitle(' · '.join(p for p in subtitle_parts if p))
+                row.set_subtitle(' · '.join(part for part in subtitle_parts if part))
                 row.set_sensitive(not already)
 
                 check = Gtk.CheckButton()

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -95,6 +95,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
 
         self._project_list_scroll = Gtk.ScrolledWindow()
         self._project_list_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self._project_list_scroll.set_min_content_height(240)
         self._project_list_scroll.set_max_content_height(360)
         self._project_list_scroll.set_propagate_natural_height(True)
         self._project_list_scroll.set_child(self._project_list_box)
@@ -263,12 +264,12 @@ class GcpDiscoveryDialog(Adw.Dialog):
         self._project_rows.append((check, project_id))
 
     def _project_filter_func(self, row):
+        # row is the Adw.ActionRow itself (it's a Gtk.ListBoxRow subclass)
         text = self._project_search.get_text().lower()
         if not text:
             return True
-        child = row.get_child()
-        title = (child.get_title() if hasattr(child, 'get_title') else '').lower()
-        subtitle = (child.get_subtitle() if hasattr(child, 'get_subtitle') else '').lower()
+        title = row.get_title().lower() if hasattr(row, 'get_title') else ''
+        subtitle = row.get_subtitle().lower() if hasattr(row, 'get_subtitle') else ''
         return text in title or text in subtitle
 
     def _on_manual_add(self, _widget):

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -261,6 +261,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
         check = Gtk.CheckButton()
         check.set_active(checked)
         check.set_valign(Gtk.Align.CENTER)
+        check.connect('toggled', self._on_project_check_toggled)
         row.add_suffix(check)
         row.set_activatable_widget(check)
         self._project_list_box.append(row)
@@ -272,7 +273,12 @@ class GcpDiscoveryDialog(Adw.Dialog):
             return True
         return text in row.get_title().lower() or text in row.get_subtitle().lower()
 
+    def _on_project_check_toggled(self, check):
+        if check.get_active():
+            self._project_list_box.remove_css_class('error')
+
     def _on_manual_add(self, _widget):
+        self._manual_entry.remove_css_class('error')
         project_id = self._manual_entry.get_text().strip()
         if not project_id:
             return
@@ -281,7 +287,6 @@ class GcpDiscoveryDialog(Adw.Dialog):
         if project_id in existing_ids:
             self._manual_entry.add_css_class('error')
             return
-        self._manual_entry.remove_css_class('error')
         self._project_search.set_visible(True)
         self._project_list_scroll.set_visible(True)
         self._project_fetch_error.set_visible(False)

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -77,11 +77,6 @@ class GcpDiscoveryDialog(Adw.Dialog):
         box.append(label_widget)
         return box
 
-    def _build_loading_page(self, label_text):
-        label = Gtk.Label(label=label_text)
-        label.add_css_class('dim-label')
-        return self._build_loading_page_with_label(label)
-
     def _build_project_page(self):
         # ── Project list (checkbox rows) ──────────────────────────────────────
         self._project_list_box = Gtk.ListBox()
@@ -264,13 +259,10 @@ class GcpDiscoveryDialog(Adw.Dialog):
         self._project_rows.append((check, project_id))
 
     def _project_filter_func(self, row):
-        # row is the Adw.ActionRow itself (it's a Gtk.ListBoxRow subclass)
         text = self._project_search.get_text().lower()
         if not text:
             return True
-        title = row.get_title().lower() if hasattr(row, 'get_title') else ''
-        subtitle = row.get_subtitle().lower() if hasattr(row, 'get_subtitle') else ''
-        return text in title or text in subtitle
+        return text in row.get_title().lower() or text in row.get_subtitle().lower()
 
     def _on_manual_add(self, _widget):
         project_id = self._manual_entry.get_text().strip()
@@ -279,17 +271,21 @@ class GcpDiscoveryDialog(Adw.Dialog):
         # Avoid duplicates
         existing_ids = {pid for _, pid in self._project_rows}
         if project_id in existing_ids:
-            self._manual_entry.set_text('')
+            self._manual_entry.add_css_class('error')
             return
+        self._manual_entry.remove_css_class('error')
         self._project_search.set_visible(True)
         self._project_list_scroll.set_visible(True)
+        self._project_fetch_error.set_visible(False)
         self._add_project_row(project_id, checked=True)
         self._manual_entry.set_text('')
 
     def _on_project_confirm(self, _btn):
         selected = [pid for check, pid in self._project_rows if check.get_active()]
         if not selected:
+            self._project_list_box.add_css_class('error')
             return
+        self._project_list_box.remove_css_class('error')
         self._start_discovery(selected)
 
     def _start_discovery(self, projects):


### PR DESCRIPTION
## Summary
- Replace the single project ID text entry in the GCP import dialog with a scrollable, filterable multi-select checkbox list populated from `gcloud projects list`, with the active gcloud project pre-checked
- Discovery runs across all selected projects and merges results into one list; group headers include the project name when multiple projects are shown
- Errors per project are collapsed into an expandable "N discovery warnings" row rather than polluting the summary label; a "Choose Different Projects" back button is shown when no instances are found

## Issues
Closes #303

## Test plan
- [ ] Open GCP import dialog — loading label steps through "Checking authentication…" → "Fetching project list…"
- [ ] Project list populates with checkboxes; active gcloud project is pre-checked
- [ ] Filter bar narrows the list live by project name or ID
- [ ] Manually adding a project ID appends a checked row; duplicates turn the entry red; empty add clears the red
- [ ] Clicking Discover with nothing checked turns the list red; checking any row immediately clears the red
- [ ] Select multiple projects → results show project-qualified group headers
- [ ] When some services error, a collapsed "N discovery warnings" expander appears at the bottom of the results list
- [ ] When no instances are found, a "Choose Different Projects" button returns to the project selection page

🤖 Generated with [Claude Code](https://claude.com/claude-code)