### PR TITLE
chore: upgrade Flatpak runtime from GNOME SDK 47 to 48

### DIFF
--- a/packaging/flatpak/xyz.shapemachine.tusk-gnome.json
+++ b/packaging/flatpak/xyz.shapemachine.tusk-gnome.json
@@ -1,7 +1,7 @@
 {
   "app-id": "xyz.shapemachine.tusk-gnome",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "command": "tusk",
   "finish-args": [


### PR DESCRIPTION
## Summary
- GNOME Platform 47 reached end-of-life on October 15, 2025; upgrade to 48 to stay on a supported runtime
- GNOME 47 and 48 share the same freedesktop SDK 24.08 base (Python 3.12), so no binary wheel changes are needed

## Issues
Closes #298

## Test plan
- [ ] Run `scripts/release.sh <version> --skip-appimage --skip-deb --skip-rpm --skip-pacman --skip-aur --skip-github` and verify the Flatpak builds successfully against the GNOME 48 runtime
- [ ] Confirm `flatpak run xyz.shapemachine.tusk-gnome` launches without runtime warnings about EOL SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)