### PR TITLE
fix: dialog font polish and connection-scoped tab cleanup

### DIFF
--- a/src/aws_discovery_dialog.py
+++ b/src/aws_discovery_dialog.py
@@ -25,6 +25,7 @@ class AwsDiscoveryDialog(Adw.Dialog):
 
     def __init__(self, existing_instance_ids=None):
         super().__init__(title='Import from AWS', content_width=540)
+        self.add_css_class('tusk-main')
         self._existing_ids = set(existing_instance_ids or [])
         self._conns = []
         self._checks = {}       # idx → (Gtk.CheckButton, conn_dict)

--- a/src/column_dialogs.py
+++ b/src/column_dialogs.py
@@ -236,6 +236,7 @@ class RenameDialog(Adw.Dialog):
 
     def __init__(self, current_name, on_rename, title='Rename'):
         super().__init__(title=title, content_width=380)
+        self.add_css_class('tusk-main')
         self._on_rename = on_rename
 
         header = Adw.HeaderBar()
@@ -287,6 +288,7 @@ class AddColumnDialog(Adw.Dialog):
 
     def __init__(self, existing_columns, on_save, schema=None, table=None):
         super().__init__(title='Add Column', content_width=420)
+        self.add_css_class('tusk-main')
         self._on_save = on_save
         self._preview_buf = None
 
@@ -485,6 +487,7 @@ class ChangeTypeDialog(Adw.Dialog):
 
     def __init__(self, col_name, current_type, on_save):
         super().__init__(title=f'Change Type: {col_name}', content_width=420)
+        self.add_css_class('tusk-main')
         self._on_save = on_save
 
         header = Adw.HeaderBar()
@@ -537,6 +540,7 @@ class SetDefaultDialog(Adw.Dialog):
 
     def __init__(self, col_name, current_default, on_save):
         super().__init__(title=f'Set Default: {col_name}', content_width=420)
+        self.add_css_class('tusk-main')
         self._on_save = on_save
 
         header = Adw.HeaderBar()
@@ -588,6 +592,7 @@ class ReorderColumnsDialog(Adw.Dialog):
 
     def __init__(self, schema, table, columns, on_execute=None):
         super().__init__(title='Reorder Columns', content_width=500)
+        self.add_css_class('tusk-main')
         self._schema = schema
         self._table = table
         self._original_order = list(columns)
@@ -785,6 +790,7 @@ class AddIndexDialog(Adw.Dialog):
 
     def __init__(self, table_name, col_names, on_save):
         super().__init__(title='Add Index', content_width=420)
+        self.add_css_class('tusk-main')
         self._on_save = on_save
         self._col_names = col_names
         self._table_name = table_name
@@ -886,6 +892,7 @@ class AddConstraintDialog(Adw.Dialog):
 
     def __init__(self, table_name, col_names, on_save):
         super().__init__(title='Add Constraint', content_width=440)
+        self.add_css_class('tusk-main')
         self._on_save = on_save
         self._table_name = table_name
         self._col_names = col_names
@@ -1066,6 +1073,7 @@ class CreateTableDialog(Adw.Dialog):
                           used by Clone Structure to pre-populate column rows
         """
         super().__init__(title='Create Table', content_width=600, content_height=520)
+        self.add_css_class('tusk-main')
         self._on_save = on_save
         self._schemas = schemas if schemas else ['public']
         self._store = Gio.ListStore(item_type=_ColDef)
@@ -1747,6 +1755,7 @@ class CreateSchemaDialog(Adw.Dialog):
 
     def __init__(self, on_save):
         super().__init__(title='New Schema', content_width=380)
+        self.add_css_class('tusk-main')
         self._on_save = on_save
 
         header = Adw.HeaderBar()
@@ -1803,6 +1812,7 @@ class CreateViewDialog(Adw.Dialog):
 
     def __init__(self, schema, on_save):
         super().__init__(title='New View', content_width=560, content_height=480)
+        self.add_css_class('tusk-main')
         self._on_save = on_save
         self._schema = schema
 

--- a/src/command_palette.py
+++ b/src/command_palette.py
@@ -82,6 +82,7 @@ class CommandPalette(Adw.Dialog):
                label is what to display (e.g. 'schema.name' or 'name(args)')
         """
         super().__init__()
+        self.add_css_class('tusk-main')
         self._items = items
         self._search_debounce_id = None
         self._build_ui()

--- a/src/connection_dialog.py
+++ b/src/connection_dialog.py
@@ -29,6 +29,7 @@ class ConnectionDialog(Adw.Dialog):
         else:
             title = 'Edit Connection'
         super().__init__(title=title, content_width=820)
+        self.add_css_class('tusk-main')
         self._connection = connection
         self._duplicate = duplicate
         self._parent = parent

--- a/src/connections_import_dialog.py
+++ b/src/connections_import_dialog.py
@@ -20,6 +20,7 @@ class ConnectionsImportDialog(Adw.Dialog):
 
     def __init__(self, incoming_conns, incoming_tags, existing_names):
         super().__init__(title='Import Connections', content_width=520, content_height=560)
+        self.add_css_class('tusk-main')
         self._incoming_tags = incoming_tags
         self._checks = {}   # conn_id → (Gtk.CheckButton, resolved_conn)
         self._build_ui(incoming_conns, existing_names)

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -24,6 +24,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
 
     def __init__(self, existing_instance_ids=None):
         super().__init__(title='Import from GCP', content_width=540)
+        self.add_css_class('tusk-main')
         self._existing_ids = set(existing_instance_ids or [])
         self._conns = []   # discovered connection dicts with internal _gcp_* keys
         self._checks = {}  # idx → (Gtk.CheckButton, conn_dict)

--- a/src/pgpass_dialog.py
+++ b/src/pgpass_dialog.py
@@ -92,6 +92,7 @@ class PgpassImportDialog(Adw.Dialog):
 
     def __init__(self, parent, entries, warnings, existing_names=None):
         super().__init__(title='Import from .pgpass', content_width=460)
+        self.add_css_class('tusk-main')
         self._entries = entries
         self._switches = []
         self._existing_names = existing_names or set()

--- a/src/role_panel.py
+++ b/src/role_panel.py
@@ -314,6 +314,7 @@ class _GrantMembershipDialog(Adw.Dialog):
 
     def __init__(self, transient_for, conn, role_name):
         super().__init__(title='Grant Membership', content_width=360)
+        self.add_css_class('tusk-main')
         self._conn = conn
         self._role_name = role_name
 
@@ -765,6 +766,7 @@ class _NewRoleDialog(Adw.Dialog):
 
     def __init__(self, conn):
         super().__init__(title='New Role', content_width=400, content_height=560)
+        self.add_css_class('tusk-main')
         self._conn = conn
 
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
@@ -909,6 +911,7 @@ class _ChangePasswordDialog(Adw.Dialog):
 
     def __init__(self, conn, role_name):
         super().__init__(title=f'Change Password — {role_name}', content_width=380)
+        self.add_css_class('tusk-main')
         self._conn = conn
         self._role_name = role_name
 

--- a/src/row_edit_dialog.py
+++ b/src/row_edit_dialog.py
@@ -20,6 +20,7 @@ class RowEditDialog(Adw.Dialog):
     def __init__(self, mode, columns, schema_info, pk_cols, initial_values, on_save):
         title = 'Insert Row' if mode == 'insert' else 'Edit Row'
         super().__init__(title=title, content_width=460)
+        self.add_css_class('tusk-main')
 
         self._mode = mode
         self._on_save = on_save

--- a/src/sponsor_dialog.py
+++ b/src/sponsor_dialog.py
@@ -11,6 +11,7 @@ _SPONSOR_URL = 'https://buy.stripe.com/14A28saQ95kI9q93qNes003'
 class SponsorDialog(Adw.Dialog):
     def __init__(self, win):
         super().__init__(title='Sponsor Tusk', content_width=380)
+        self.add_css_class('tusk-main')
         self._win = win
 
         toolbar_view = Adw.ToolbarView()

--- a/src/stale_dialog.py
+++ b/src/stale_dialog.py
@@ -29,6 +29,7 @@ class StaleConnectionsDialog(Adw.Dialog):
 
     def __init__(self, store, conn_health=None):
         super().__init__(title='Clean Up Stale Connections', content_width=520, content_height=560)
+        self.add_css_class('tusk-main')
         self._store = store
         self._conn_health = conn_health or {}
         self._checks = {}  # conn_id → Gtk.CheckButton

--- a/src/tags_dialog.py
+++ b/src/tags_dialog.py
@@ -56,6 +56,7 @@ class TagsDialog(Adw.Dialog):
 
     def __init__(self, store):
         super().__init__(title='Manage Tags', content_width=480, content_height=560)
+        self.add_css_class('tusk-main')
         self._store = store
         _ensure_css()
         self._build_ui()

--- a/src/window.py
+++ b/src/window.py
@@ -1291,14 +1291,15 @@ class TuskWindow(Adw.ApplicationWindow):
             self._browser.clear()
 
     def _set_active_conn(self, conn):
-        # Close all table and function tabs belonging to the previous connection
+        # Close all connection-scoped tabs belonging to the previous connection
         if self._active_conn_id:
             pages = self._tab_view.get_pages()
             to_close = [
                 pages.get_item(i)
                 for i in range(pages.get_n_items())
                 if getattr(pages.get_item(i), '_tab_id', '').startswith(
-                    (f'table:{self._active_conn_id}:', f'fn:{self._active_conn_id}:')
+                    (f'table:{self._active_conn_id}:', f'fn:{self._active_conn_id}:',
+                     f'role:{self._active_conn_id}:', f'activity:{self._active_conn_id}')
                 )
             ]
             for page in to_close:

--- a/src/window.py
+++ b/src/window.py
@@ -1291,8 +1291,9 @@ class TuskWindow(Adw.ApplicationWindow):
             self._browser.clear()
 
     def _set_active_conn(self, conn):
-        # Close all connection-scoped tabs belonging to the previous connection
-        if self._active_conn_id:
+        # Close all connection-scoped tabs only when switching to a different connection
+        new_id = conn['id'] if conn else None
+        if self._active_conn_id and new_id != self._active_conn_id:
             pages = self._tab_view.get_pages()
             cid = self._active_conn_id
             to_close = [

--- a/src/window.py
+++ b/src/window.py
@@ -51,7 +51,6 @@ class TuskWindow(Adw.ApplicationWindow):
         self._conn_health = {}         # conn_id → {status, msg, ts}
         self._conn_mgr_rows = {}       # conn_id → manager list row
         self._alive = True
-        self._update_status_timeout_id = None
         self.connect('destroy', lambda _: setattr(self, '_alive', False))
         self._sidebar_css = Gtk.CssProvider()
         self._main_css = Gtk.CssProvider()
@@ -601,12 +600,6 @@ class TuskWindow(Adw.ApplicationWindow):
         footer_spacer = Gtk.Box()
         footer_spacer.set_hexpand(True)
         footer.append(footer_spacer)
-
-        self._update_status_label = Gtk.Label()
-        self._update_status_label.add_css_class('caption')
-        self._update_status_label.add_css_class('dim-label')
-        self._update_status_label.set_visible(False)
-        footer.append(self._update_status_label)
 
         self._update_check_btn = Gtk.Button()
         self._update_check_btn.add_css_class('flat')
@@ -1359,7 +1352,6 @@ class TuskWindow(Adw.ApplicationWindow):
         self._update_check_btn.set_sensitive(False)
         self._update_btn_stack.set_visible_child_name('spinner')
         self._update_btn_spinner.start()
-        self._update_status_label.set_visible(False)
         self._update_banner.set_revealed(False)
         threading.Thread(target=self._fetch_latest_version, daemon=True).start()
 
@@ -1381,25 +1373,13 @@ class TuskWindow(Adw.ApplicationWindow):
         self._update_btn_stack.set_visible_child_name('label')
         self._update_check_btn.set_sensitive(True)
         if error or not latest_tag:
-            self._show_update_status('Could not check for updates')
+            self.show_toast('Could not check for updates')
             return
         if self._version_newer(config.VERSION, latest_tag):
             self._update_banner.set_title(f'Tusk v{latest_tag} is available')
             self._update_banner.set_revealed(True)
         else:
-            self._show_update_status(f'Up to date (v{latest_tag})')
-
-    def _show_update_status(self, text):
-        if self._update_status_timeout_id is not None:
-            GLib.source_remove(self._update_status_timeout_id)
-        self._update_status_label.set_text(text)
-        self._update_status_label.set_visible(True)
-        self._update_status_timeout_id = GLib.timeout_add(5000, self._hide_update_status)
-
-    def _hide_update_status(self):
-        self._update_status_timeout_id = None
-        self._update_status_label.set_visible(False)
-        return GLib.SOURCE_REMOVE
+            self.show_toast(f'Up to date (v{latest_tag})')
 
     def _on_update_banner_clicked(self, _banner):
         Gtk.show_uri(self, 'https://github.com/Shape-Machine/tusk-gnome/releases/latest',

--- a/src/window.py
+++ b/src/window.py
@@ -1294,13 +1294,13 @@ class TuskWindow(Adw.ApplicationWindow):
         # Close all connection-scoped tabs belonging to the previous connection
         if self._active_conn_id:
             pages = self._tab_view.get_pages()
+            cid = self._active_conn_id
             to_close = [
                 pages.get_item(i)
                 for i in range(pages.get_n_items())
-                if getattr(pages.get_item(i), '_tab_id', '').startswith(
-                    (f'table:{self._active_conn_id}:', f'fn:{self._active_conn_id}:',
-                     f'role:{self._active_conn_id}:', f'activity:{self._active_conn_id}')
-                )
+                if (tab_id := getattr(pages.get_item(i), '_tab_id', ''))
+                and (tab_id.startswith((f'table:{cid}:', f'fn:{cid}:', f'role:{cid}:'))
+                     or tab_id == f'activity:{cid}')
             ]
             for page in to_close:
                 self._tab_view.close_page(page)


### PR DESCRIPTION
## Summary
- Apply `tusk-main` CSS class to all dialogs so the content font is consistent across the entire app, not just the main window
- Extend connection-scoped tab cleanup to include role and activity tabs when switching connections (previously only table/fn tabs closed)
- Use exact match for activity tab ID in cleanup to avoid potential prefix collision with other conn IDs

## Issues
Closes #310
Closes #311

## Test plan
- Open several dialogs (connection, column, tags, role, etc.) and verify text renders with the correct app font
- Open a role tab and an activity tab, then switch to a different connection — both tabs should close automatically
- Verify table/fn tabs still close on connection switch as before