### PR TITLE
fix: connection manager toolbar polish and sort improvements

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -47,7 +47,8 @@ class TuskWindow(Adw.ApplicationWindow):
         self._conn_search = ''
         _saved = prefs.get('conn_sort', 'manual')
         _valid = {'name-asc', 'name-desc', 'last-connected-asc', 'last-connected-desc', 'manual'}
-        self._conn_sort_state = _saved if _saved in _valid else 'manual'
+        _migrate = {'name': 'name-asc', 'last-connected': 'last-connected-asc'}
+        self._conn_sort_state = _saved if _saved in _valid else _migrate.get(_saved, 'manual')
         self._active_tag_filters = set()
         self._warned_conn_ids = set()  # conn_ids warned this session (warn_on_connect)
         self._conn_health = {}         # conn_id → {status, msg, ts}

--- a/src/window.py
+++ b/src/window.py
@@ -46,6 +46,7 @@ class TuskWindow(Adw.ApplicationWindow):
         self._active_conn = None       # full conn dict with password
         self._conn_search = ''
         self._conn_sort = prefs.get('conn_sort', 'manual')
+        self._conn_sort_asc = prefs.get('conn_sort_asc', True)
         self._active_tag_filters = set()
         self._warned_conn_ids = set()  # conn_ids warned this session (warn_on_connect)
         self._conn_health = {}         # conn_id → {status, msg, ts}
@@ -492,7 +493,8 @@ class TuskWindow(Adw.ApplicationWindow):
             _item.set_attribute_value('target', GLib.Variant('s', _val))
             sort_menu.append_item(_item)
         self._sort_btn = Gtk.MenuButton()
-        self._sort_btn.set_icon_name('view-sort-ascending-symbolic')
+        _sort_icon = 'view-sort-ascending-symbolic' if self._conn_sort_asc else 'view-sort-descending-symbolic'
+        self._sort_btn.set_icon_name(_sort_icon)
         self._sort_btn.set_tooltip_text('Sort connections')
         self._sort_btn.set_menu_model(sort_menu)
         self._sort_btn.add_css_class('flat')
@@ -1437,8 +1439,18 @@ class TuskWindow(Adw.ApplicationWindow):
         self._mgr_list.invalidate_filter()
 
     def _on_sort_changed(self, key):
-        self._conn_sort = key
-        prefs.put('conn_sort', key)
+        if key == 'manual':
+            self._conn_sort = key
+            self._conn_sort_asc = True
+        elif key == self._conn_sort:
+            self._conn_sort_asc = not self._conn_sort_asc
+        else:
+            self._conn_sort = key
+            self._conn_sort_asc = True
+        prefs.put('conn_sort', self._conn_sort)
+        prefs.put('conn_sort_asc', self._conn_sort_asc)
+        icon = 'view-sort-ascending-symbolic' if self._conn_sort_asc else 'view-sort-descending-symbolic'
+        self._sort_btn.set_icon_name(icon)
         self._mgr_list.invalidate_sort()
 
     def _mgr_filter_row(self, row):
@@ -1468,14 +1480,15 @@ class TuskWindow(Adw.ApplicationWindow):
         if not hasattr(a, '_conn') or not hasattr(b, '_conn'):
             return 0
         ca, cb = a._conn, b._conn
+        result = 0
         if self._conn_sort == 'name':
             na, nb = ca.get('name', '').lower(), cb.get('name', '').lower()
-            return -1 if na < nb else (1 if na > nb else 0)
-        if self._conn_sort == 'last-connected':
+            result = -1 if na < nb else (1 if na > nb else 0)
+        elif self._conn_sort == 'last-connected':
             ta = ca.get('last_connected') or ''
             tb = cb.get('last_connected') or ''
-            return -1 if ta > tb else (1 if ta < tb else 0)
-        return 0  # manual: preserve insertion order
+            result = -1 if ta > tb else (1 if ta < tb else 0)
+        return result if self._conn_sort_asc else -result
 
     def _refresh_tag_strip(self):
         while (child := self._mgr_tag_strip.get_first_child()):

--- a/src/window.py
+++ b/src/window.py
@@ -494,7 +494,7 @@ class TuskWindow(Adw.ApplicationWindow):
             ('Name (Z–A)',              'name-desc'),
             ('Last Connected (Newest)', 'last-connected-asc'),
             ('Last Connected (Oldest)', 'last-connected-desc'),
-            ('Manual',                  'manual'),
+            ('Default',                  'manual'),
         ]:
             _item = Gio.MenuItem.new(_label, 'win.conn-sort')
             _item.set_attribute_value('target', GLib.Variant('s', _val))

--- a/src/window.py
+++ b/src/window.py
@@ -590,8 +590,8 @@ class TuskWindow(Adw.ApplicationWindow):
 
         content_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         content_box.set_vexpand(True)
-        content_box.append(tag_scroll)
         content_box.append(mgr_scroll)
+        content_box.append(tag_scroll)
         mgr_box.append(content_box)
 
         # ── Branding footer ───────────────────────────────────────────────────────

--- a/src/window.py
+++ b/src/window.py
@@ -45,8 +45,9 @@ class TuskWindow(Adw.ApplicationWindow):
         self._active_conn_id = None
         self._active_conn = None       # full conn dict with password
         self._conn_search = ''
-        self._conn_sort = prefs.get('conn_sort', 'manual')
-        self._conn_sort_asc = prefs.get('conn_sort_asc', True)
+        _saved = prefs.get('conn_sort', 'manual')
+        _valid = {'name-asc', 'name-desc', 'last-connected-asc', 'last-connected-desc', 'manual'}
+        self._conn_sort_state = _saved if _saved in _valid else 'manual'
         self._active_tag_filters = set()
         self._warned_conn_ids = set()  # conn_ids warned this session (warn_on_connect)
         self._conn_health = {}         # conn_id → {status, msg, ts}
@@ -112,7 +113,7 @@ class TuskWindow(Adw.ApplicationWindow):
         add('import-from-aws',           lambda *_: self._on_import_from_aws())
         add('cleanup-stale',              lambda *_: self._on_cleanup_stale())
         self._sort_action = Gio.SimpleAction.new_stateful(
-            'conn-sort', GLib.VariantType.new('s'), GLib.Variant('s', self._conn_sort)
+            'conn-sort', GLib.VariantType.new('s'), GLib.Variant('s', self._conn_sort_state)
         )
         self._sort_action.connect('activate', lambda a, v: (
             a.set_state(v), self._on_sort_changed(v.get_string())
@@ -488,12 +489,18 @@ class TuskWindow(Adw.ApplicationWindow):
         mgr_toolbar.set_margin_end(MARGIN_MD)
 
         sort_menu = Gio.Menu()
-        for _label, _val in [('Name (A–Z)', 'name'), ('Last Connected', 'last-connected'), ('Manual', 'manual')]:
+        for _label, _val in [
+            ('Name (A–Z)',              'name-asc'),
+            ('Name (Z–A)',              'name-desc'),
+            ('Last Connected (Newest)', 'last-connected-asc'),
+            ('Last Connected (Oldest)', 'last-connected-desc'),
+            ('Manual',                  'manual'),
+        ]:
             _item = Gio.MenuItem.new(_label, 'win.conn-sort')
             _item.set_attribute_value('target', GLib.Variant('s', _val))
             sort_menu.append_item(_item)
         self._sort_btn = Gtk.MenuButton()
-        _sort_icon = 'view-sort-ascending-symbolic' if self._conn_sort_asc else 'view-sort-descending-symbolic'
+        _sort_icon = 'view-sort-descending-symbolic' if self._conn_sort_state.endswith('-desc') else 'view-sort-ascending-symbolic'
         self._sort_btn.set_icon_name(_sort_icon)
         self._sort_btn.set_tooltip_text('Sort connections')
         self._sort_btn.set_menu_model(sort_menu)
@@ -1175,7 +1182,7 @@ class TuskWindow(Adw.ApplicationWindow):
             self._store.update(row._conn)
         except KeyringUnavailableError:
             pass  # non-fatal — don't block the connection
-        if self._conn_sort == 'last-connected':
+        if self._conn_sort_state in ('last-connected-asc', 'last-connected-desc'):
             self._mgr_list.invalidate_sort()
 
         self._set_active_conn(conn)
@@ -1438,18 +1445,10 @@ class TuskWindow(Adw.ApplicationWindow):
         self._conn_search = entry.get_text()
         self._mgr_list.invalidate_filter()
 
-    def _on_sort_changed(self, key):
-        if key == 'manual':
-            self._conn_sort = key
-            self._conn_sort_asc = True
-        elif key == self._conn_sort:
-            self._conn_sort_asc = not self._conn_sort_asc
-        else:
-            self._conn_sort = key
-            self._conn_sort_asc = True
-        prefs.put('conn_sort', self._conn_sort)
-        prefs.put('conn_sort_asc', self._conn_sort_asc)
-        icon = 'view-sort-ascending-symbolic' if self._conn_sort_asc else 'view-sort-descending-symbolic'
+    def _on_sort_changed(self, state):
+        self._conn_sort_state = state
+        prefs.put('conn_sort', state)
+        icon = 'view-sort-descending-symbolic' if state.endswith('-desc') else 'view-sort-ascending-symbolic'
         self._sort_btn.set_icon_name(icon)
         self._mgr_list.invalidate_sort()
 
@@ -1480,15 +1479,17 @@ class TuskWindow(Adw.ApplicationWindow):
         if not hasattr(a, '_conn') or not hasattr(b, '_conn'):
             return 0
         ca, cb = a._conn, b._conn
-        result = 0
-        if self._conn_sort == 'name':
+        state = self._conn_sort_state
+        if state in ('name-asc', 'name-desc'):
             na, nb = ca.get('name', '').lower(), cb.get('name', '').lower()
             result = -1 if na < nb else (1 if na > nb else 0)
-        elif self._conn_sort == 'last-connected':
+            return result if state == 'name-asc' else -result
+        if state in ('last-connected-asc', 'last-connected-desc'):
             ta = ca.get('last_connected') or ''
             tb = cb.get('last_connected') or ''
             result = -1 if ta > tb else (1 if ta < tb else 0)
-        return result if self._conn_sort_asc else -result
+            return result if state == 'last-connected-asc' else -result
+        return 0  # manual
 
     def _refresh_tag_strip(self):
         while (child := self._mgr_tag_strip.get_first_child()):

--- a/src/window.py
+++ b/src/window.py
@@ -110,10 +110,13 @@ class TuskWindow(Adw.ApplicationWindow):
         add('import-from-gcp',           lambda *_: self._on_import_from_gcp())
         add('import-from-aws',           lambda *_: self._on_import_from_aws())
         add('cleanup-stale',              lambda *_: self._on_cleanup_stale())
-        for _key in ('name', 'last-connected', 'manual'):
-            _a = Gio.SimpleAction.new(f'conn-sort-{_key}', None)
-            _a.connect('activate', lambda _act, _par, k=_key: self._on_sort_changed(k))
-            self.add_action(_a)
+        self._sort_action = Gio.SimpleAction.new_stateful(
+            'conn-sort', GLib.VariantType.new('s'), GLib.Variant('s', self._conn_sort)
+        )
+        self._sort_action.connect('activate', lambda a, v: (
+            a.set_state(v), self._on_sort_changed(v.get_string())
+        ))
+        self.add_action(self._sort_action)
         self._refresh_action = Gio.SimpleAction.new('refresh-tab', None)
         self._refresh_action.connect('activate', lambda *_: self._refresh_current_tab())
         self._refresh_action.set_enabled(False)
@@ -484,9 +487,10 @@ class TuskWindow(Adw.ApplicationWindow):
         mgr_toolbar.set_margin_end(MARGIN_MD)
 
         sort_menu = Gio.Menu()
-        sort_menu.append('Name (A–Z)', 'win.conn-sort-name')
-        sort_menu.append('Last Connected', 'win.conn-sort-last-connected')
-        sort_menu.append('Manual', 'win.conn-sort-manual')
+        for _label, _val in [('Name (A–Z)', 'name'), ('Last Connected', 'last-connected'), ('Manual', 'manual')]:
+            _item = Gio.MenuItem.new(_label, 'win.conn-sort')
+            _item.set_attribute_value('target', GLib.Variant('s', _val))
+            sort_menu.append_item(_item)
         self._sort_btn = Gtk.MenuButton()
         self._sort_btn.set_icon_name('view-sort-ascending-symbolic')
         self._sort_btn.set_tooltip_text('Sort connections')
@@ -515,7 +519,6 @@ class TuskWindow(Adw.ApplicationWindow):
         overflow_btn.set_tooltip_text('More actions')
         overflow_btn.set_menu_model(overflow_menu)
         overflow_btn.add_css_class('flat')
-        mgr_toolbar.append(overflow_btn)
 
         mgr_add_btn = Adw.SplitButton(label='Add Connection')
         mgr_add_btn.add_css_class('suggested-action')
@@ -528,6 +531,7 @@ class TuskWindow(Adw.ApplicationWindow):
         mgr_add_menu.append('Import from AWS…', 'win.import-from-aws')
         mgr_add_btn.set_menu_model(mgr_add_menu)
         mgr_toolbar.append(mgr_add_btn)
+        mgr_toolbar.append(overflow_btn)
 
         mgr_box.append(mgr_toolbar)
 


### PR DESCRIPTION
## Summary
- Move overflow (⋮) button to the right of "Add Connection" so the primary CTA is prominent
- Replace three stateless sort actions with a single stateful action showing a radio checkmark on the active option
- Expand sort menu to 5 explicit options: Name A–Z/Z–A, Last Connected Newest/Oldest, Default
- Sort button icon reflects current direction (↑/↓)
- Rename "Manual" sort to "Default"
- Move tag filter column to the right of the connection list
- Migrate old `conn_sort` pref values to the new asc/desc format so user preferences are preserved on upgrade

## Issues
Closes #313
Closes #314

## Test plan
- Verify toolbar order: sort ↕ | Manage Tags | Search | Add Connection | ⋮
- Open sort menu — confirm radio checkmark appears on the active option
- Select Name (A–Z) → list sorts alphabetically, button shows ↑
- Select Name (Z–A) → list reverses, button shows ↓
- Select Last Connected (Newest/Oldest) and verify order flips
- Verify sort preference persists after restart
- Confirm tag filter column appears on the right of the connection list