### PR TITLE
perf/fix/feat: favourites performance, Cloud SQL proxy & connection dialog

### DIFF
--- a/src/connection_dialog.py
+++ b/src/connection_dialog.py
@@ -28,7 +28,7 @@ class ConnectionDialog(Adw.Dialog):
             title = 'New Connection'
         else:
             title = 'Edit Connection'
-        super().__init__(title=title, content_width=820)
+        super().__init__(title=title, content_width=900)
         self.add_css_class('tusk-main')
         self._connection = connection
         self._duplicate = duplicate
@@ -168,6 +168,31 @@ class ConnectionDialog(Adw.Dialog):
 
         ssh_group.add(self._ssh_row)
 
+        # ── Cloud SQL Auth Proxy ──────────────────────────────────────────────
+        cloud_group = Adw.PreferencesGroup(title='Cloud SQL Auth Proxy')
+
+        self._proxy_row = Adw.ExpanderRow(title='Use Cloud SQL Auth Proxy')
+        self._proxy_row.set_show_enable_switch(True)
+        self._proxy_row.set_subtitle(
+            'Route connections through cloud-sql-proxy. Requires the '
+            'cloud-sql-proxy binary on your PATH.'
+        )
+
+        self._proxy_instance_row = Adw.EntryRow(title='Instance ID')
+        self._proxy_instance_row.set_tooltip_text(
+            'Cloud SQL instance connection name — found in the Google Cloud console.\n'
+            'Format: project-id:region:instance-name'
+        )
+
+        self._proxy_auth_row = Adw.ComboRow(title='Authentication')
+        self._proxy_auth_row.set_subtitle('How Tusk authenticates with the database')
+        auth_model = Gtk.StringList.new(['Password', 'IAM (Google Identity)'])
+        self._proxy_auth_row.set_model(auth_model)
+
+        self._proxy_row.add_row(self._proxy_instance_row)
+        self._proxy_row.add_row(self._proxy_auth_row)
+        cloud_group.add(self._proxy_row)
+
         # ── Populate values ───────────────────────────────────────────────────
         if conn and self._duplicate:
             self._name_row.set_text(conn['name'] + ' copy')
@@ -204,6 +229,20 @@ class ConnectionDialog(Adw.Dialog):
             keyring_failed = True
         self._ssh_passphrase_row.set_text(ssh_passphrase)
         self._default_schema_row.set_text(conn.get('default_schema', '') if conn else '')
+
+        proxy_enabled = conn.get('cloud_proxy_enabled', False) if conn else False
+        self._proxy_row.set_enable_expansion(proxy_enabled)
+        self._proxy_row.set_expanded(proxy_enabled)
+        self._proxy_instance_row.set_text(conn.get('cloud_instance_id', '') if conn else '')
+        self._proxy_auth_row.set_selected(
+            1 if (conn.get('cloud_auth_mode') == 'iam' if conn else False) else 0
+        )
+        self._pre_proxy_host = None
+        if proxy_enabled:
+            self._host_row.set_sensitive(False)
+        self._proxy_row.connect('notify::enable-expansion', self._on_proxy_toggled)
+        self._proxy_auth_row.connect('notify::selected', self._on_proxy_auth_changed)
+        self._on_proxy_auth_changed()  # apply initial state
 
         self._keyring_banner = Adw.Banner(
             title="Passwords can't be saved — the system password manager isn't available. Try logging out and back in."
@@ -266,7 +305,6 @@ class ConnectionDialog(Adw.Dialog):
         right_col.append(options_group)
         if tags_group:
             right_col.append(tags_group)
-        right_col.append(ssh_group)
 
         two_col = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)
         two_col.append(left_col)
@@ -281,6 +319,8 @@ class ConnectionDialog(Adw.Dialog):
         content.append(uri_group)
         content.append(self._uri_error_label)
         content.append(two_col)
+        content.append(ssh_group)
+        content.append(cloud_group)
         content.append(self._keyring_banner)
 
         # ── Test / Save ───────────────────────────────────────────────────────
@@ -347,6 +387,22 @@ class ConnectionDialog(Adw.Dialog):
                 self._aurora_reader_row.set_visible(False)
             elif not self._aurora_reader_row.get_text().strip():
                 self._aurora_reader_row.set_visible(False)
+
+    def _on_proxy_toggled(self, *_):
+        enabled = self._proxy_row.get_enable_expansion()
+        if enabled:
+            self._pre_proxy_host = self._host_row.get_text()
+            self._host_row.set_text('localhost')
+            self._host_row.set_sensitive(False)
+        else:
+            self._host_row.set_sensitive(True)
+            if self._pre_proxy_host is not None:
+                self._host_row.set_text(self._pre_proxy_host)
+                self._pre_proxy_host = None
+
+    def _on_proxy_auth_changed(self, *_):
+        iam = self._proxy_auth_row.get_selected() == 1
+        self._password_row.set_sensitive(not iam)
 
     def _on_reader_text_changed(self, *_):
         # If the user edits the reader field directly, it's no longer auto-filled
@@ -450,6 +506,20 @@ class ConnectionDialog(Adw.Dialog):
             'ssh_key_path': self._ssh_key_row.get_text().strip(),
             'ssh_passphrase': self._ssh_passphrase_row.get_text(),
         }
+        proxy_enabled = self._proxy_row.get_enable_expansion()
+        is_cloud = proxy_enabled or bool(
+            self._connection and self._connection.get('cloud_provider')
+        )
+        if is_cloud:
+            params.update({
+                'cloud_proxy_enabled': proxy_enabled,
+                'cloud_instance_id': self._proxy_instance_row.get_text().strip(),
+                'cloud_auth_mode': 'iam' if self._proxy_auth_row.get_selected() == 1 else 'password',
+                'cloud_provider': (
+                    self._connection.get('cloud_provider', 'gcp-cloudsql')
+                    if self._connection else 'gcp-cloudsql'
+                ),
+            })
         default_schema = self._default_schema_row.get_text().strip()
         if default_schema:
             params['default_schema'] = default_schema
@@ -503,6 +573,8 @@ class ConnectionDialog(Adw.Dialog):
         host = self._host_row.get_text().strip()
         username = self._username_row.get_text().strip()
 
+        proxy_instance = self._proxy_instance_row.get_text().strip()
+
         valid = True
         for row, value in (
             (self._name_row, name),
@@ -514,6 +586,12 @@ class ConnectionDialog(Adw.Dialog):
             else:
                 row.add_css_class('error')
                 valid = False
+
+        if self._proxy_row.get_enable_expansion() and not proxy_instance:
+            self._proxy_instance_row.add_css_class('error')
+            valid = False
+        else:
+            self._proxy_instance_row.remove_css_class('error')
 
         if not valid:
             return
@@ -527,6 +605,7 @@ class ConnectionDialog(Adw.Dialog):
         except ValueError:
             ssh_port = 22
 
+        proxy_enabled = self._proxy_row.get_enable_expansion()
         conn = {
             'id': str(uuid.uuid4()) if self._duplicate else (
                 self._connection['id'] if self._connection else str(uuid.uuid4())
@@ -546,6 +625,19 @@ class ConnectionDialog(Adw.Dialog):
             'ssh_passphrase': self._ssh_passphrase_row.get_text(),
             'tags': sorted(self._selected_tags),
         }
+        is_cloud = proxy_enabled or bool(
+            self._connection and self._connection.get('cloud_provider')
+        )
+        if is_cloud:
+            conn.update({
+                'cloud_proxy_enabled': proxy_enabled,
+                'cloud_instance_id': self._proxy_instance_row.get_text().strip(),
+                'cloud_auth_mode': 'iam' if self._proxy_auth_row.get_selected() == 1 else 'password',
+                'cloud_provider': (
+                    self._connection.get('cloud_provider', 'gcp-cloudsql')
+                    if self._connection else 'gcp-cloudsql'
+                ),
+            })
         default_schema = self._default_schema_row.get_text().strip()
         if default_schema:
             conn['default_schema'] = default_schema

--- a/src/connection_dialog.py
+++ b/src/connection_dialog.py
@@ -233,12 +233,14 @@ class ConnectionDialog(Adw.Dialog):
         proxy_enabled = conn.get('cloud_proxy_enabled', False) if conn else False
         self._proxy_row.set_enable_expansion(proxy_enabled)
         self._proxy_row.set_expanded(proxy_enabled)
-        self._proxy_instance_row.set_text(conn.get('cloud_instance_id', '') if conn else '')
+        self._proxy_instance_row.set_text((conn.get('cloud_instance_id') or '') if conn else '')
         self._proxy_auth_row.set_selected(
             1 if (conn.get('cloud_auth_mode') == 'iam' if conn else False) else 0
         )
         self._pre_proxy_host = None
         if proxy_enabled:
+            self._pre_proxy_host = self._host_row.get_text()
+            self._host_row.set_text('localhost')
             self._host_row.set_sensitive(False)
         self._proxy_row.connect('notify::enable-expansion', self._on_proxy_toggled)
         self._proxy_auth_row.connect('notify::selected', self._on_proxy_auth_changed)
@@ -538,19 +540,9 @@ class ConnectionDialog(Adw.Dialog):
 
     def _run_test(self, params):
         try:
-            import psycopg
-            from tunnel import open_tunnel
-
-            with open_tunnel(params) as (host, port):
-                with psycopg.connect(
-                    host=host,
-                    port=port,
-                    dbname=params['database'],
-                    user=params['username'],
-                    password=params['password'],
-                    connect_timeout=10,
-                ):
-                    pass
+            from tunnel import open_db
+            with open_db(params):
+                pass
             GLib.idle_add(self._on_test_result, True, None)
         except Exception as e:
             GLib.idle_add(self._on_test_result, False, str(e))

--- a/src/db_browser.py
+++ b/src/db_browser.py
@@ -464,11 +464,14 @@ class DbBrowser(Gtk.Box):
     def _expand_favourites(self):
         """Expand the Favourites group row in the tree."""
         it = self._store.get_iter_first()
-        if it and self._store.get_value(it, COL_TYPE) == 'favourites':
-            path = self._store.get_path(it)
-            fpath = self._filter.convert_child_path_to_path(path)
-            if fpath:
-                self._tree.expand_row(fpath, False)
+        while it:
+            if self._store.get_value(it, COL_TYPE) == 'favourites':
+                path = self._store.get_path(it)
+                fpath = self._filter.convert_child_path_to_path(path)
+                if fpath:
+                    self._tree.expand_row(fpath, False)
+                return
+            it = self._store.iter_next(it)
 
     def _on_db_selected(self, dropdown, _param):
         if self._db_switch_inhibit:
@@ -819,7 +822,7 @@ class DbBrowser(Gtk.Box):
             fav_it = self._store.append(None, [
                 'starred-symbolic', 'Favourites', 'favourites', conn, '', ''
             ])
-            for fav in pinned:
+            for fav in sorted(pinned, key=lambda f: (f['table'].lower(), f['schema'].lower())):
                 label = f'{fav["table"]} ({fav["schema"]})'
                 self._store.append(fav_it, [
                     'x-office-spreadsheet-symbolic', label, 'favourite',
@@ -1277,13 +1280,62 @@ class DbBrowser(Gtk.Box):
         if not conn:
             return
         self._favs.add(conn.get('id', ''), schema, table, item_type)
-        self.load(conn)
+        self._refresh_favourites_in_tree(conn)
 
     def _do_unpin(self, conn, schema, table):
         if not conn:
             return
         self._favs.remove(conn.get('id', ''), schema, table)
-        self.load(conn)
+        self._refresh_favourites_in_tree(conn)
+
+    def _refresh_favourites_in_tree(self, conn):
+        """Surgically update only the Favourites section without reloading the entire tree."""
+        conn_id = conn.get('id', '')
+        pinned = self._favs.get(conn_id)
+
+        # Find existing 'favourites' parent row in the store
+        fav_it = None
+        it = self._store.get_iter_first()
+        while it:
+            if self._store.get_value(it, COL_TYPE) == 'favourites':
+                fav_it = it
+                break
+            it = self._store.iter_next(it)
+
+        if not pinned:
+            if fav_it:
+                self._store.remove(fav_it)
+            return
+
+        if fav_it:
+            # Clear all existing children and repopulate
+            child = self._store.iter_children(fav_it)
+            while child:
+                self._store.remove(child)
+                child = self._store.iter_children(fav_it)
+        else:
+            # Insert favourites after Server Activity (index 1) to match load() ordering.
+            # Fall back to index 0 if the activity row isn't present yet.
+            insert_pos = 0
+            it = self._store.get_iter_first()
+            if it and self._store.get_value(it, COL_TYPE) == 'activity':
+                insert_pos = 1
+            fav_it = self._store.insert(None, insert_pos, [
+                'starred-symbolic', 'Favourites', 'favourites', conn, '', ''
+            ])
+
+        for fav in sorted(pinned, key=lambda f: (f['table'].lower(), f['schema'].lower())):
+            label = f'{fav["table"]} ({fav["schema"]})'
+            self._store.append(fav_it, [
+                'x-office-spreadsheet-symbolic', label, 'favourite',
+                conn, fav['schema'], fav['table'],
+            ])
+
+        # Ensure the favourites section stays expanded
+        fav_path = self._store.get_path(fav_it)
+        filter_path = self._filter.convert_child_path_to_path(fav_path)
+        if filter_path:
+            self._tree.expand_row(filter_path, False)
 
     def _on_row_activated(self, tree, path, _col):
         it = self._filter.get_iter(path)

--- a/src/gcp_discovery.py
+++ b/src/gcp_discovery.py
@@ -163,14 +163,6 @@ def save_cloud_sql_server_ca(instance, project):
         return None
 
 
-def _has_public_ip(instance):
-    """Return True if the Cloud SQL instance has a public IP address."""
-    for ip in instance.get('ipAddresses', []):
-        if ip.get('type') == 'PRIMARY':
-            return True
-    return False
-
-
 def _iam_auth_enabled(instance):
     """Return True if the Cloud SQL instance has IAM database authentication on."""
     for flag in instance.get('settings', {}).get('databaseFlags', []):
@@ -179,25 +171,22 @@ def _iam_auth_enabled(instance):
     return False
 
 
-def build_cloud_sql_conn(instance, project, fetch_cert=True):
+def build_cloud_sql_conn(instance, project):
     """Convert a Cloud SQL instance dict into a Tusk connection dict."""
     name = instance.get('name', '')
     region = instance.get('region', '')
     db_version = instance.get('databaseVersion', '')  # e.g. POSTGRES_15
     connection_name = instance.get('connectionName', f'{project}:{region}:{name}')
 
-    has_pub_ip = _has_public_ip(instance)
-    proxy_enabled = not has_pub_ip
+    proxy_enabled = True  # always use Cloud SQL Auth Proxy; direct public-IP connections require IP allowlisting which is fragile
     iam_enabled = _iam_auth_enabled(instance)
 
-    # Pick a reachable host: public IP if available, else localhost (proxy)
+    # Always connect via proxy — host must be localhost so the reachability
+    # check and connection subtitle reflect what is actually used.
     host = 'localhost'
-    for ip in instance.get('ipAddresses', []):
-        if ip.get('type') == 'PRIMARY':
-            host = ip['ipAddress']
-            break
 
-    cert_path = save_cloud_sql_server_ca(instance, project) if fetch_cert else None
+    # Proxy connections skip SSL in _psycopg_kwargs(), so no cert is needed.
+    cert_path = None
 
     tags = ['gcp']
     if region:
@@ -216,7 +205,7 @@ def build_cloud_sql_conn(instance, project, fetch_cert=True):
         'cloud_auth_mode': 'iam' if iam_enabled else 'password',
         'cloud_proxy_enabled': proxy_enabled,
         'cloud_proxy_port': None,
-        'ssl_mode': 'require',
+        'ssl_mode': 'require' if not proxy_enabled else None,
         'ssl_root_cert': cert_path,
         'tags': tags,
         '_gcp_service': 'Cloud SQL',

--- a/src/gcp_discovery_dialog.py
+++ b/src/gcp_discovery_dialog.py
@@ -319,7 +319,7 @@ class GcpDiscoveryDialog(Adw.Dialog):
             try:
                 instances = gcp_discovery.discover_cloud_sql(project)
                 for inst in instances:
-                    conn = gcp_discovery.build_cloud_sql_conn(inst, project, fetch_cert=True)
+                    conn = gcp_discovery.build_cloud_sql_conn(inst, project)
                     conns.append(conn)
             except RuntimeError as e:
                 errors.append(f'{project} / Cloud SQL: {e}')


### PR DESCRIPTION
## Summary

- **Favourites pin/unpin**: surgical tree update instead of full DB schema reload — no SQL queries, no spinner, no flicker (Closes #316)
- **Favourites ordering**: section always inserts at index 1 (after Server Activity); `_expand_favourites()` searches all root rows instead of only checking index 0 (Closes #319)
- **Favourites sort**: rows sorted alphabetically by table name on every pin/unpin and reload (Closes #320)
- **Cloud SQL proxy**: discovered connections always route through Auth Proxy; `conn['host']` stays `localhost`; skip unnecessary CA cert disk writes; remove dead `_has_public_ip()` and `fetch_cert` parameter (Closes #318)
- **Connection dialog — proxy UI**: new Cloud SQL Auth Proxy expander section — toggle + Instance ID + Authentication mode (Password / IAM); host auto-locks to `localhost` when enabled; Password field disabled when IAM selected; pre-filled for GCP-discovered connections; validates Instance ID before saving; cloud fields only written for cloud connections (Closes #321)
- **Connection dialog — layout**: widened to 900px; SSH Tunnel and Cloud SQL Auth Proxy moved to full-width sections below the two-column area (Closes #322)

## Test plan
- [ ] Pin a table — Favourites appears instantly, no loading spinner, rest of tree undisturbed
- [ ] Unpin a table — row disappears instantly; unpinning the last favourite removes the section entirely
- [ ] Favourites section stays expanded after pin/unpin
- [ ] Favourites are sorted alphabetically
- [ ] After a full connection reload, Favourites sits below Server Activity and is auto-expanded
- [ ] Discover a Cloud SQL instance — `conn['host']` is `localhost`, subtitle shows `localhost`, proxy is used for the connection
- [ ] Reachability ping on a Cloud SQL connection shows accurate status (no false "Unreachable")
- [ ] Open the connection dialog on a GCP-discovered connection — Cloud SQL Auth Proxy section is pre-filled and enabled, host field locked to `localhost`
- [ ] Toggle proxy off in dialog — host field unlocks and restores previous value
- [ ] Select IAM auth mode — Password field becomes insensitive
- [ ] Select Password auth mode — Password field re-enables
- [ ] Manually enable proxy on a new connection — enter instance ID, save, connect via proxy
- [ ] Save with proxy enabled but blank Instance ID — Instance ID field highlights as error, save blocked
- [ ] Non-cloud connection saved — no `cloud_auth_mode`/`cloud_provider` fields in JSON
- [ ] Connection dialog wider and less cramped; SSH Tunnel and Cloud SQL Auth Proxy full-width below two-column area

🤖 Generated with [Claude Code](https://claude.com/claude-code)