### PR TITLE
feat: Azure Database for PostgreSQL discovery and import via az CLI

### DIFF
--- a/src/azure_discovery.py
+++ b/src/azure_discovery.py
@@ -40,7 +40,7 @@ def _friendly_azure_error(stderr, fallback):
             'No Azure subscriptions found for your account.\n\n'
             'Make sure your account has access to at least one subscription.'
         )
-    if 'cloud not be found' in low or 'resourcenotfound' in low:
+    if 'could not be found' in low or 'resourcenotfound' in low:
         return (
             'The requested Azure resource could not be found.\n\n'
             'Check that your subscription ID is correct and that you have access.'
@@ -84,6 +84,19 @@ def get_active_account():
     The returned dict has at least: id, name, isDefault, tenantId, user.name
     """
     return _az('account', 'show')
+
+
+def get_active_username():
+    """Return the current Azure AD user's UPN (email), or '' on failure.
+
+    Used as the PostgreSQL username when cloud_auth_mode='iam', since Azure AD
+    auth requires the UPN rather than the admin login stored in the profile.
+    """
+    try:
+        account = get_active_account()
+        return account.get('user', {}).get('name', '')
+    except RuntimeError:
+        return ''
 
 
 def list_subscriptions():

--- a/src/azure_discovery.py
+++ b/src/azure_discovery.py
@@ -1,0 +1,225 @@
+"""Azure Database for PostgreSQL discovery — Flexible Server via az CLI.
+
+All public functions return plain dicts / strings and never touch GTK.
+The dialog (azure_discovery_dialog.py) calls these from a background thread.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import urllib.request
+import uuid
+
+CERT_DIR = os.path.join(os.path.expanduser('~'), '.config', 'tusk', 'certs')
+
+_AZURE_CA_URL = 'https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem'
+_AZURE_CA_PATH = os.path.join(CERT_DIR, 'azure-postgres-ca.pem')
+
+
+# ── az CLI helpers ─────────────────────────────────────────────────────────────
+
+def _friendly_azure_error(stderr, fallback):
+    """Return a user-readable error message for a failed az command."""
+    detail = stderr or fallback
+    low = detail.lower()
+    if 'authorizationerror' in low or 'authorization_failed' in low or 'does not have authorization' in low:
+        return (
+            'Permission denied. Your Azure account does not have the required permissions.\n\n'
+            'Required role: Reader on the subscription, or\n'
+            '  Microsoft.DBforPostgreSQL/flexibleServers/read\n\n'
+            'Ask your Azure administrator to grant you the Reader role on the subscription.'
+        )
+    if 'please run' in low and 'az login' in low:
+        return (
+            'Not signed in to Azure.\n\n'
+            'Run `az login` in a terminal, then try again.'
+        )
+    if 'no subscriptions found' in low:
+        return (
+            'No Azure subscriptions found for your account.\n\n'
+            'Make sure your account has access to at least one subscription.'
+        )
+    if 'cloud not be found' in low or 'resourcenotfound' in low:
+        return (
+            'The requested Azure resource could not be found.\n\n'
+            'Check that your subscription ID is correct and that you have access.'
+        )
+    return detail
+
+
+def azcli_available():
+    """Return True if `az` is on $PATH."""
+    return shutil.which('az') is not None
+
+
+def _az(*args):
+    """Run an az CLI command and return parsed JSON output.
+
+    Raises RuntimeError with a user-readable message on failure.
+    """
+    cmd = ['az'] + list(args) + ['--output', 'json']
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f'az CLI timed out running: {" ".join(cmd)}')
+    except FileNotFoundError:
+        raise RuntimeError('az CLI not found on $PATH.')
+
+    if result.returncode != 0:
+        raise RuntimeError(_friendly_azure_error(
+            result.stderr.strip(), f'az exited with code {result.returncode}'
+        ))
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f'Could not parse az output: {e}')
+
+
+# ── Authentication & account ───────────────────────────────────────────────────
+
+def get_active_account():
+    """Return the active az account dict, or raise RuntimeError if not authenticated.
+
+    The returned dict has at least: id, name, isDefault, tenantId, user.name
+    """
+    return _az('account', 'show')
+
+
+def list_subscriptions():
+    """Return a list of accessible subscription dicts.
+
+    Each dict has: id, name, isDefault, state, tenantId
+    Raises RuntimeError on failure.
+    """
+    data = _az('account', 'list', '--all')
+    subs = data if isinstance(data, list) else []
+    # Filter to enabled subscriptions only
+    return [s for s in subs if s.get('state', '').lower() == 'enabled']
+
+
+# ── SSL cert ───────────────────────────────────────────────────────────────────
+
+def get_azure_ca_cert():
+    """Return the Azure PostgreSQL CA cert path — downloads it if not cached.
+
+    Returns None if the download fails; callers should still import with
+    ssl_mode='require' and surface a non-fatal warning to the user.
+    """
+    if os.path.exists(_AZURE_CA_PATH):
+        return _AZURE_CA_PATH
+    tmp = _AZURE_CA_PATH + '.tmp'
+    try:
+        os.makedirs(CERT_DIR, exist_ok=True)
+        with urllib.request.urlopen(_AZURE_CA_URL, timeout=15) as resp:
+            with open(tmp, 'wb') as f:
+                f.write(resp.read())
+        os.replace(tmp, _AZURE_CA_PATH)
+        return _AZURE_CA_PATH
+    except Exception:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        return None
+
+
+# ── Discovery ──────────────────────────────────────────────────────────────────
+
+def discover_azure_postgres(subscription_id):
+    """Return a list of Flexible Server instance dicts for the subscription."""
+    data = _az(
+        'postgres', 'flexible-server', 'list',
+        '--subscription', subscription_id,
+    )
+    return data if isinstance(data, list) else []
+
+
+def detect_single_server(subscription_id):
+    """Return a list of (deprecated) Single Server instance dicts.
+
+    Returns an empty list on error — Single Server detection is best-effort.
+    """
+    try:
+        data = _az(
+            'postgres', 'server', 'list',
+            '--subscription', subscription_id,
+        )
+        return data if isinstance(data, list) else []
+    except RuntimeError:
+        return []
+
+
+# ── Connection builder ─────────────────────────────────────────────────────────
+
+def build_azure_conn(server, subscription_id, cert_path=None):
+    """Convert an Azure Flexible Server dict into a Tusk connection dict."""
+    name = server.get('name', '')
+    resource_group = server.get('resourceGroup', '')
+    location = server.get('location', '')
+    version = server.get('version', '')
+    fqdn = server.get('fullyQualifiedDomainName', f'{name}.postgres.database.azure.com')
+    admin_login = server.get('administratorLogin', 'postgres')
+    resource_id = server.get('id', '')
+
+    tags = ['azure']
+    if location:
+        tags.append(location)
+
+    return {
+        'id': str(uuid.uuid4()),
+        'name': f'{name} (Azure)',
+        'host': fqdn,
+        'port': 5432,
+        'database': 'postgres',
+        'username': admin_login,
+        'cloud_provider': 'azure-database',
+        'cloud_instance_id': resource_id or name,
+        'cloud_region': location,
+        'cloud_auth_mode': 'password',
+        'cloud_proxy_enabled': False,
+        'cloud_proxy_port': None,
+        'ssl_mode': 'require',
+        'ssl_root_cert': cert_path,
+        'tags': tags,
+        '_azure_service': 'Flexible Server',
+        '_azure_version': version,
+        '_azure_resource_group': resource_group,
+        '_azure_location': location,
+        '_azure_subscription_id': subscription_id,
+    }
+
+
+# ── Azure AD token ─────────────────────────────────────────────────────────────
+
+def get_azure_ad_token():
+    """Return a short-lived Azure AD access token for PostgreSQL authentication.
+
+    Uses the oss-rdbms resource type as required by Azure Database for PostgreSQL.
+    Raises RuntimeError if the az CLI is unavailable or the call fails.
+    """
+    try:
+        result = subprocess.run(
+            [
+                'az', 'account', 'get-access-token',
+                '--resource-type', 'oss-rdbms',
+                '--output', 'json',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except FileNotFoundError:
+        raise RuntimeError('az CLI not found on $PATH.')
+    except subprocess.TimeoutExpired:
+        raise RuntimeError('az account get-access-token timed out.')
+    if result.returncode != 0:
+        raise RuntimeError(
+            _friendly_azure_error(result.stderr.strip(), 'az account get-access-token failed.')
+        )
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f'Could not parse az token output: {e}')
+    token = data.get('accessToken', '')
+    if not token:
+        raise RuntimeError('az returned an empty access token.')
+    return token

--- a/src/azure_discovery_dialog.py
+++ b/src/azure_discovery_dialog.py
@@ -253,10 +253,6 @@ class AzureDiscoveryDialog(Adw.Dialog):
 
     def _on_subscription_confirm(self, _btn):
         selected = [sub for check, sub in self._subscription_rows if check.get_active()]
-        if not selected:
-            self._sub_list_box.add_css_class('error')
-            return
-        self._sub_list_box.remove_css_class('error')
         self._start_discovery(selected[0])
 
     def _start_discovery(self, subscription):
@@ -273,7 +269,6 @@ class AzureDiscoveryDialog(Adw.Dialog):
         sub_id = subscription.get('id', '')
         conns = []
         errors = []
-        single_server_names = []
 
         cert_path = azure_discovery.get_azure_ca_cert()
         if cert_path is None:

--- a/src/azure_discovery_dialog.py
+++ b/src/azure_discovery_dialog.py
@@ -1,0 +1,443 @@
+"""Azure Database for PostgreSQL discovery dialog — Flexible Server via az CLI."""
+
+import threading
+
+import gi
+
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+
+from gi.repository import Gtk, Adw, GObject, GLib
+
+import azure_discovery
+
+
+class AzureDiscoveryDialog(Adw.Dialog):
+    """Discover and import Azure Database for PostgreSQL Flexible Server instances.
+
+    Emits 'import-confirmed' with a list of connection dicts when the user
+    clicks Import Selected.
+    """
+
+    __gsignals__ = {
+        'import-confirmed': (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+    }
+
+    def __init__(self, existing_instance_ids=None):
+        super().__init__(title='Import from Azure', content_width=540)
+        self.add_css_class('tusk-main')
+        self._existing_ids = set(existing_instance_ids or [])
+        self._conns = []
+        self._checks = {}           # idx → (Gtk.CheckButton, conn_dict)
+        self._subscription_rows = []  # list of (check_button, subscription_dict)
+        self._build_ui()
+
+    # ── UI skeleton ────────────────────────────────────────────────────────────
+
+    def _build_ui(self):
+        self._header = Adw.HeaderBar()
+
+        self._stack = Gtk.Stack()
+        self._stack.set_transition_type(Gtk.StackTransitionType.CROSSFADE)
+
+        self._loading_label_widget = Gtk.Label(label='Checking az CLI…')
+        self._loading_label_widget.add_css_class('dim-label')
+        self._loading_page = self._build_loading_page(self._loading_label_widget)
+        self._stack.add_named(self._loading_page, 'loading')
+
+        self._subscription_page = self._build_subscription_page()
+        self._stack.add_named(self._subscription_page, 'subscription')
+
+        self._results_page = self._build_results_page()
+        self._stack.add_named(self._results_page, 'results')
+
+        self._error_page = self._build_error_page()
+        self._stack.add_named(self._error_page, 'error')
+
+        toolbar_view = Adw.ToolbarView()
+        toolbar_view.add_top_bar(self._header)
+        toolbar_view.set_content(self._stack)
+        self.set_child(toolbar_view)
+
+        threading.Thread(target=self._check_azure, daemon=True).start()
+
+    def _build_loading_page(self, label_widget):
+        spinner = Gtk.Spinner()
+        spinner.set_size_request(32, 32)
+        spinner.start()
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_halign(Gtk.Align.CENTER)
+        box.set_valign(Gtk.Align.CENTER)
+        box.set_vexpand(True)
+        box.append(spinner)
+        box.append(label_widget)
+        return box
+
+    def _build_subscription_page(self):
+        self._sub_list_box = Gtk.ListBox()
+        self._sub_list_box.add_css_class('boxed-list')
+        self._sub_list_box.set_selection_mode(Gtk.SelectionMode.NONE)
+        self._sub_list_box.set_filter_func(self._sub_filter_func)
+
+        self._sub_search = Gtk.SearchEntry(placeholder_text='Filter subscriptions…')
+        self._sub_search.connect('search-changed',
+                                 lambda _: self._sub_list_box.invalidate_filter())
+
+        self._sub_list_scroll = Gtk.ScrolledWindow()
+        self._sub_list_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self._sub_list_scroll.set_min_content_height(200)
+        self._sub_list_scroll.set_max_content_height(320)
+        self._sub_list_scroll.set_propagate_natural_height(True)
+        self._sub_list_scroll.set_child(self._sub_list_box)
+
+        list_group = Adw.PreferencesGroup(
+            title='Azure Subscriptions',
+            description='Select a subscription to discover databases in.',
+        )
+
+        discover_btn = Gtk.Button(label='Discover Databases')
+        discover_btn.add_css_class('suggested-action')
+        discover_btn.add_css_class('pill')
+        discover_btn.set_halign(Gtk.Align.CENTER)
+        discover_btn.connect('clicked', self._on_subscription_confirm)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
+        box.set_margin_top(20)
+        box.set_margin_bottom(20)
+        box.set_margin_start(20)
+        box.set_margin_end(20)
+        box.set_vexpand(True)
+        box.append(list_group)
+        box.append(self._sub_search)
+        box.append(self._sub_list_scroll)
+        box.append(discover_btn)
+
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_propagate_natural_height(True)
+        scroll.set_child(box)
+        return scroll
+
+    def _build_results_page(self):
+        self._summary_label = Gtk.Label()
+        self._summary_label.add_css_class('dim-label')
+        self._summary_label.set_wrap(True)
+        self._summary_label.set_xalign(0)
+
+        self._results_list = Gtk.ListBox()
+        self._results_list.add_css_class('boxed-list')
+        self._results_list.set_selection_mode(Gtk.SelectionMode.NONE)
+
+        self._import_btn = Gtk.Button(label='Import Selected')
+        self._import_btn.add_css_class('suggested-action')
+        self._import_btn.add_css_class('pill')
+        self._import_btn.set_halign(Gtk.Align.CENTER)
+        self._import_btn.connect('clicked', self._on_import)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_margin_top(16)
+        box.set_margin_bottom(20)
+        box.set_margin_start(20)
+        box.set_margin_end(20)
+        box.append(self._summary_label)
+        box.append(self._results_list)
+        box.append(self._import_btn)
+
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_propagate_natural_height(True)
+        scroll.set_child(box)
+        return scroll
+
+    def _build_error_page(self):
+        self._error_back_btn = Gtk.Button(label='Choose Different Subscription')
+        self._error_back_btn.add_css_class('pill')
+        self._error_back_btn.set_halign(Gtk.Align.CENTER)
+        self._error_back_btn.set_visible(False)
+        self._error_back_btn.connect('clicked',
+                                     lambda _: self._stack.set_visible_child_name('subscription'))
+
+        self._error_status = Adw.StatusPage(
+            icon_name='dialog-error-symbolic',
+            title='Discovery Failed',
+            child=self._error_back_btn,
+        )
+        return self._error_status
+
+    # ── Background checks ──────────────────────────────────────────────────────
+
+    def _check_azure(self):
+        if not azure_discovery.azcli_available():
+            GLib.idle_add(self._show_error,
+                'az CLI not found',
+                'Install the Azure CLI and sign in before using this feature.\n\n'
+                'Download: https://learn.microsoft.com/cli/azure/install-azure-cli')
+            return
+
+        GLib.idle_add(self._loading_label_widget.set_text, 'Checking credentials…')
+        try:
+            azure_discovery.get_active_account()
+        except RuntimeError as e:
+            GLib.idle_add(self._show_error, 'Not authenticated', str(e))
+            return
+
+        GLib.idle_add(self._loading_label_widget.set_text, 'Fetching subscriptions…')
+        try:
+            subscriptions = azure_discovery.list_subscriptions()
+        except RuntimeError as e:
+            GLib.idle_add(self._show_error, 'Could not list subscriptions', str(e))
+            return
+
+        if not subscriptions:
+            GLib.idle_add(self._show_error,
+                'No subscriptions found',
+                'No enabled Azure subscriptions are accessible with your account.\n\n'
+                'Make sure your account has access to at least one subscription.')
+            return
+
+        GLib.idle_add(self._on_azure_checked, subscriptions)
+
+    def _on_azure_checked(self, subscriptions):
+        # If there's exactly one subscription, skip the picker and go straight to discovery
+        if len(subscriptions) == 1:
+            self._start_discovery(subscriptions[0])
+            return
+        self._populate_subscription_list(subscriptions)
+        self._stack.set_visible_child_name('subscription')
+
+    def _populate_subscription_list(self, subscriptions):
+        self._subscription_rows = []
+
+        while True:
+            row = self._sub_list_box.get_first_child()
+            if row is None:
+                break
+            self._sub_list_box.remove(row)
+
+        for sub in subscriptions:
+            self._add_subscription_row(sub, checked=sub.get('isDefault', False))
+
+        # Pre-select first if none is default
+        if self._subscription_rows and not any(
+            check.get_active() for check, _ in self._subscription_rows
+        ):
+            self._subscription_rows[0][0].set_active(True)
+
+    def _add_subscription_row(self, sub, checked=False):
+        sub_id = sub.get('id', '')
+        sub_name = sub.get('name', sub_id)
+        row = Adw.ActionRow(title=sub_name, subtitle=sub_id)
+        check = Gtk.CheckButton()
+        check.set_active(checked)
+        check.set_valign(Gtk.Align.CENTER)
+        # Radio-button behaviour: only one subscription at a time
+        if self._subscription_rows:
+            check.set_group(self._subscription_rows[0][0])
+        check.connect('toggled', self._on_sub_check_toggled)
+        row.add_suffix(check)
+        row.set_activatable_widget(check)
+        self._sub_list_box.append(row)
+        self._subscription_rows.append((check, sub))
+
+    def _sub_filter_func(self, row):
+        text = self._sub_search.get_text().lower()
+        if not text:
+            return True
+        title = (row.get_title() or '').lower()
+        subtitle = (row.get_subtitle() or '').lower()
+        return text in title or text in subtitle
+
+    def _on_sub_check_toggled(self, check):
+        if check.get_active():
+            self._sub_list_box.remove_css_class('error')
+
+    def _on_subscription_confirm(self, _btn):
+        selected = [sub for check, sub in self._subscription_rows if check.get_active()]
+        if not selected:
+            self._sub_list_box.add_css_class('error')
+            return
+        self._sub_list_box.remove_css_class('error')
+        self._start_discovery(selected[0])
+
+    def _start_discovery(self, subscription):
+        sub_name = subscription.get('name', subscription.get('id', ''))
+        self._loading_label_widget.set_text(f'Discovering databases in {sub_name}…')
+        self._stack.set_visible_child_name('loading')
+        threading.Thread(
+            target=self._run_discovery,
+            args=(subscription,),
+            daemon=True,
+        ).start()
+
+    def _run_discovery(self, subscription):
+        sub_id = subscription.get('id', '')
+        conns = []
+        errors = []
+        single_server_names = []
+
+        cert_path = azure_discovery.get_azure_ca_cert()
+        if cert_path is None:
+            errors.append(
+                'Azure CA certificate download failed — connections will use ssl_mode=require '
+                'without a pinned certificate.'
+            )
+
+        try:
+            servers = azure_discovery.discover_azure_postgres(sub_id)
+            for server in servers:
+                conns.append(azure_discovery.build_azure_conn(server, sub_id, cert_path=cert_path))
+        except RuntimeError as e:
+            errors.append(f'Flexible Server discovery: {e}')
+
+        # Best-effort Single Server detection for deprecation warning
+        single_servers = azure_discovery.detect_single_server(sub_id)
+        single_server_names = [s.get('name', '') for s in single_servers if s.get('name')]
+
+        GLib.idle_add(self._show_results, conns, errors, single_server_names)
+
+    # ── Results rendering ──────────────────────────────────────────────────────
+
+    def _show_results(self, conns, errors, single_server_names):
+        self._conns = conns
+        self._checks = {}
+
+        while True:
+            row = self._results_list.get_first_child()
+            if row is None:
+                break
+            self._results_list.remove(row)
+
+        if not conns:
+            msg = 'No PostgreSQL Flexible Server instances found in the selected subscription.'
+            if errors:
+                msg += '\n\nErrors:\n' + '\n'.join(errors)
+            self._show_error('No instances found', msg, show_back=True)
+            return
+
+        # Group by resource group, then location
+        groups = {}  # (resource_group, location) → [conn]
+        for conn in conns:
+            key = (
+                conn.get('_azure_resource_group', ''),
+                conn.get('_azure_location', ''),
+            )
+            groups.setdefault(key, []).append(conn)
+
+        idx = 0
+        for (resource_group, location), group_conns in sorted(groups.items()):
+            title = resource_group or 'Unknown resource group'
+            subtitle = location or ''
+            header_row = Adw.ActionRow(title=title, subtitle=subtitle)
+            header_row.set_activatable(False)
+            header_row.add_css_class('dim-label')
+            self._results_list.append(header_row)
+
+            for conn in group_conns:
+                already = conn.get('cloud_instance_id', '') in self._existing_ids
+                row = Adw.ActionRow(title=conn['name'])
+                host = conn.get('host', '')
+                port = conn.get('port', 5432)
+                endpoint_str = f'{host}:{port}' if host else ''
+                subtitle_parts = [conn.get('_azure_version', ''), endpoint_str]
+                if already:
+                    subtitle_parts.append('Already imported')
+                row.set_subtitle(' · '.join(p for p in subtitle_parts if p))
+                row.set_sensitive(not already)
+
+                check = Gtk.CheckButton()
+                check.set_active(not already)
+                check.set_sensitive(not already)
+                check.set_valign(Gtk.Align.CENTER)
+                row.add_suffix(check)
+                row.set_activatable_widget(check)
+                self._results_list.append(row)
+                self._checks[idx] = (check, conn)
+                idx += 1
+
+        total = len(conns)
+        already_count = sum(
+            1 for c in conns if c.get('cloud_instance_id', '') in self._existing_ids
+        )
+        summary = f'{total} Flexible Server instance{"s" if total != 1 else ""} found.'
+        if already_count:
+            summary += f' {already_count} already imported.'
+        self._summary_label.set_text(summary)
+
+        if single_server_names:
+            n = len(single_server_names)
+            names_str = ', '.join(single_server_names[:5])
+            if n > 5:
+                names_str += f' and {n - 5} more'
+            expander = Adw.ExpanderRow(
+                title=f'{n} deprecated Single Server instance{"s" if n != 1 else ""} detected',
+                subtitle='Single Server is retired — migrate to Flexible Server',
+            )
+            expander.set_icon_name('dialog-warning-symbolic')
+            warning_label = Gtk.Label(
+                label=(
+                    f'The following Single Server instance{"s" if n != 1 else ""} '
+                    f'{"were" if n != 1 else "was"} found: {names_str}.\n\n'
+                    'Azure Database for PostgreSQL Single Server is retired. '
+                    'Please migrate to Flexible Server.\n\n'
+                    'Only Flexible Server instances are imported by Tusk.'
+                )
+            )
+            warning_label.set_wrap(True)
+            warning_label.set_xalign(0)
+            warning_label.add_css_class('dim-label')
+            warning_label.set_selectable(True)
+            warning_label.set_margin_start(12)
+            warning_label.set_margin_end(12)
+            warning_label.set_margin_top(8)
+            warning_label.set_margin_bottom(8)
+            warning_row = Gtk.ListBoxRow()
+            warning_row.set_selectable(False)
+            warning_row.set_activatable(False)
+            warning_row.set_child(warning_label)
+            expander.add_row(warning_row)
+            self._results_list.append(expander)
+
+        if errors:
+            n = len(errors)
+            expander = Adw.ExpanderRow(
+                title=f'{n} discovery warning{"s" if n != 1 else ""}',
+                subtitle='Some resources could not be queried — click to expand',
+            )
+            expander.set_icon_name('dialog-warning-symbolic')
+            error_label = Gtk.Label(label='\n\n'.join(errors))
+            error_label.set_wrap(True)
+            error_label.set_xalign(0)
+            error_label.add_css_class('dim-label')
+            error_label.set_selectable(True)
+            error_label.set_margin_start(12)
+            error_label.set_margin_end(12)
+            error_label.set_margin_top(8)
+            error_label.set_margin_bottom(8)
+            error_row = Gtk.ListBoxRow()
+            error_row.set_selectable(False)
+            error_row.set_activatable(False)
+            error_row.set_child(error_label)
+            expander.add_row(error_row)
+            self._results_list.append(expander)
+
+        self._stack.set_visible_child_name('results')
+
+    def _show_error(self, title, description, show_back=False):
+        self._error_status.set_title(title)
+        self._error_status.set_description(description)
+        self._error_back_btn.set_visible(show_back)
+        self._stack.set_visible_child_name('error')
+
+    # ── Import ─────────────────────────────────────────────────────────────────
+
+    def _on_import(self, _btn):
+        selected = [
+            conn for (check, conn) in self._checks.values()
+            if check.get_active()
+        ]
+        if not selected:
+            return
+        # Strip internal _azure_* keys before emitting
+        clean = [{k: v for k, v in c.items() if not k.startswith('_azure_')} for c in selected]
+        self.emit('import-confirmed', clean)
+        self.close()

--- a/src/meson.build
+++ b/src/meson.build
@@ -57,6 +57,8 @@ tusk_sources = [
   'gcp_discovery_dialog.py',
   'aws_discovery.py',
   'aws_discovery_dialog.py',
+  'azure_discovery.py',
+  'azure_discovery_dialog.py',
 ]
 
 install_data(tusk_sources, install_dir: pkgdatadir)

--- a/src/tunnel.py
+++ b/src/tunnel.py
@@ -138,8 +138,12 @@ def open_db(conn, autocommit=False):
                 conn.get('cloud_region', ''),
             )
         elif provider.startswith('azure-'):
-            from azure_discovery import get_azure_ad_token
+            from azure_discovery import get_azure_ad_token, get_active_username
             password = get_azure_ad_token()
+            # Azure AD auth requires the UPN as username, not the stored admin login
+            upn = get_active_username()
+            if upn:
+                conn = {**conn, 'username': upn}
         else:
             from gcp_discovery import get_iam_token
             password = get_iam_token()

--- a/src/tunnel.py
+++ b/src/tunnel.py
@@ -137,6 +137,9 @@ def open_db(conn, autocommit=False):
                 conn.get('username', ''),
                 conn.get('cloud_region', ''),
             )
+        elif provider.startswith('azure-'):
+            from azure_discovery import get_azure_ad_token
+            password = get_azure_ad_token()
         else:
             from gcp_discovery import get_iam_token
             password = get_iam_token()

--- a/src/tunnel.py
+++ b/src/tunnel.py
@@ -140,10 +140,21 @@ def open_db(conn, autocommit=False):
         elif provider.startswith('azure-'):
             from azure_discovery import get_azure_ad_token, get_active_username
             password = get_azure_ad_token()
-            # Azure AD auth requires the UPN as username, not the stored admin login
+            # Azure AD auth requires the UPN as username, not the stored admin login.
+            # If UPN lookup fails and the stored username doesn't look like a UPN, fail
+            # loudly rather than attempting auth with the wrong username.
             upn = get_active_username()
+            stored = conn.get('username', '')
             if upn:
-                conn = {**conn, 'username': upn}
+                conn = {**conn, 'username': upn, 'ssl_mode': 'require'}
+            elif '@' in stored:
+                conn = {**conn, 'ssl_mode': 'require'}
+            else:
+                raise RuntimeError(
+                    'Could not determine your Azure AD UPN.\n\n'
+                    'Run `az login` to refresh your credentials, or set the connection '
+                    'username to your Azure AD email address (e.g. user@example.com).'
+                )
         else:
             from gcp_discovery import get_iam_token
             password = get_iam_token()

--- a/src/window.py
+++ b/src/window.py
@@ -19,6 +19,7 @@ from connections import ConnectionStore, KeyringUnavailableError
 from connection_dialog import ConnectionDialog
 from gcp_discovery_dialog import GcpDiscoveryDialog
 from aws_discovery_dialog import AwsDiscoveryDialog
+from azure_discovery_dialog import AzureDiscoveryDialog
 from style import MARGIN_XS, MARGIN_SM, MARGIN_MD
 from db_browser import DbBrowser
 from file_explorer import FileExplorer
@@ -112,6 +113,7 @@ class TuskWindow(Adw.ApplicationWindow):
         add('import-connections-json',    lambda *_: self._on_import_connections_json())
         add('import-from-gcp',           lambda *_: self._on_import_from_gcp())
         add('import-from-aws',           lambda *_: self._on_import_from_aws())
+        add('import-from-azure',         lambda *_: self._on_import_from_azure())
         add('cleanup-stale',              lambda *_: self._on_cleanup_stale())
         self._sort_action = Gio.SimpleAction.new_stateful(
             'conn-sort', GLib.VariantType.new('s'), GLib.Variant('s', self._conn_sort_state)
@@ -363,6 +365,7 @@ class TuskWindow(Adw.ApplicationWindow):
         add_menu.append('Import connections…', 'win.import-connections-json')
         add_menu.append('Import from GCP…', 'win.import-from-gcp')
         add_menu.append('Import from AWS…', 'win.import-from-aws')
+        add_menu.append('Import from Azure…', 'win.import-from-azure')
         add_btn.set_menu_model(add_menu)
         header.pack_end(add_btn)
 
@@ -524,6 +527,7 @@ class TuskWindow(Adw.ApplicationWindow):
         add_section.append('Import connections…', 'win.import-connections-json')
         add_section.append('Import from GCP…', 'win.import-from-gcp')
         add_section.append('Import from AWS…', 'win.import-from-aws')
+        add_section.append('Import from Azure…', 'win.import-from-azure')
 
         manage_section = Gio.Menu()
         manage_section.append('Check all connections', 'win.check-all-health')
@@ -1902,6 +1906,34 @@ class TuskWindow(Adw.ApplicationWindow):
                 self._add_connection_row(conn, tags_registry=tags_reg)
         self._refresh_tag_strip()
         msg = f'{added} connection{"s" if added != 1 else ""} imported from AWS.'
+        if skipped:
+            msg += f' {skipped} skipped.'
+        self._show_toast(msg)
+
+    def _on_import_from_azure(self):
+        existing_instance_ids = {
+            c.get('cloud_instance_id')
+            for c in self._store.list()
+            if c.get('cloud_instance_id')
+        }
+        dlg = AzureDiscoveryDialog(existing_instance_ids=existing_instance_ids)
+        dlg.connect('import-confirmed', self._on_azure_import_confirmed)
+        dlg.present(self)
+
+    def _on_azure_import_confirmed(self, _dlg, conns):
+        # Build the tags registry for Azure tags that may not exist yet
+        tags_registry = {}
+        for conn in conns:
+            for tag in conn.get('tags', []):
+                tags_registry.setdefault(tag, {'color': '#0078D4', 'warn_on_connect': False})
+        added, skipped = self._store.bulk_import(conns, tags_registry)
+        existing_ids = set(self._conn_mgr_rows.keys())
+        tags_reg = self._store.get_tags_registry()
+        for conn in self._store.list():
+            if conn['id'] not in existing_ids:
+                self._add_connection_row(conn, tags_registry=tags_reg)
+        self._refresh_tag_strip()
+        msg = f'{added} connection{"s" if added != 1 else ""} imported from Azure.'
         if skipped:
             msg += f' {skipped} skipped.'
         self._show_toast(msg)


### PR DESCRIPTION
## Summary
- Adds "Import from Azure…" to the connections panel, following the same pattern as the existing GCP and AWS integrations
- Discovers all Flexible Server instances across a subscription via the `az` CLI; results are grouped by resource group with duplicate detection and Single Server deprecation warnings
- Includes Azure AD auth support (superseding #267) and CA cert auto-download (superseding #270)

## Issues
Closes #282

## Test plan
- [ ] "Import from Azure…" appears in the Add Connection menu (both header and sidebar)
- [ ] With `az` not on PATH: error page shown with download link
- [ ] With `az` on PATH but not logged in: error page prompts `az login`
- [ ] Single subscription: subscription picker is skipped, discovery starts immediately
- [ ] Multiple subscriptions: subscription picker appears with active sub pre-selected
- [ ] Results grouped by resource group; version and hostname shown in subtitle
- [ ] Single Server instances (if any) show a deprecation warning expander
- [ ] Already-imported instances shown greyed out with "Already imported"
- [ ] Importing creates connections with `ssl_mode=require` and Azure CA cert path
- [ ] `azure` and location tags created with Azure blue (#0078D4)
- [ ] Toast confirms count of imported connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)